### PR TITLE
PR2: common infrastructure (pose config, VideoFile.path, logging)

### DIFF
--- a/dj_local_conf_example.json
+++ b/dj_local_conf_example.json
@@ -47,7 +47,7 @@
       "storage": "/your/base/path/kachery_storage",
       "temp": "/your/base/path/tmp"
     },
-    "dlc_dirs": {
+    "pose_dirs": {
       "base": "/your/base/path/deeplabcut",
       "project": "/your/base/path/deeplabcut/projects",
       "video": "/your/base/path/deeplabcut/video",

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -1096,7 +1096,7 @@ def validate_schema(schema: Dict[str, Any]) -> None:
         raise ValueError("Schema 'directory_schema' is empty")
 
     # Check for required prefixes (kachery is optional)
-    required_prefixes = {"spyglass", "dlc", "moseq"}
+    required_prefixes = {"spyglass", "pose", "moseq"}
     actual_prefixes = set(dir_schema.keys())
     missing_prefixes = required_prefixes - actual_prefixes
     if missing_prefixes:
@@ -1370,11 +1370,11 @@ def create_database_config(
                 "storage": str(dirs["kachery_storage"]),
                 "temp": str(dirs["kachery_temp"]),
             },
-            "dlc_dirs": {
+            "pose_dirs": {
                 "base": str(base_dir / "deeplabcut"),
-                "project": str(dirs["dlc_project"]),
-                "video": str(dirs["dlc_video"]),
-                "output": str(dirs["dlc_output"]),
+                "project": str(dirs["pose_project"]),
+                "video": str(dirs["pose_video"]),
+                "output": str(dirs["pose_output"]),
             },
             "moseq_dirs": {
                 "base": str(base_dir / "moseq"),

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1007,24 +1007,9 @@ class VideoFile(SpyglassMixin, dj.Imported):
             if stored.exists():
                 return stored.as_posix()
 
-        nwb_path = Nwbfile.get_abs_path(key["nwb_file_name"])
-        nwbf = get_nwb_file(nwb_path)
+        # VideoFile.make() only ingests ImageSeries objects, so the stored
+        # object id resolves to the video's ImageSeries.
         nwb_video = (cls & key).fetch_nwb()[0]["video_file"]
-
-        # If the stored object ID resolves to a non-ImageSeries (e.g. a stale
-        # reference to a ProcessingModule), search the NWB for ImageSeries.
-        if not isinstance(nwb_video, pynwb.image.ImageSeries):
-            image_series = [
-                obj
-                for obj in nwbf.objects.values()
-                if isinstance(obj, pynwb.image.ImageSeries)
-            ]
-            if not image_series:
-                raise FileNotFoundError(
-                    f"No ImageSeries found in {key['nwb_file_name']}"
-                )
-            nwb_video = image_series[0]
-
         video_filename = nwb_video.name
 
         # Try the NWB object name first (often equals the real filename)
@@ -1078,84 +1063,60 @@ class VideoFile(SpyglassMixin, dj.Imported):
     def _narrow_key_lookup(self, video_path: str, restriction=None) -> tuple:
         """Select a single VideoFile PK for *video_path* under *restriction*.
 
-        Fetches ``(KEY, path)`` rows from ``VideoFile & restriction``, then
-        tries two strategies in order of decreasing reliability:
+        *restriction* scopes VideoFile to a session (the sole caller passes
+        ``{"nwb_file_name": ...}``); this then picks the one ``video_file_num``
+        matching *video_path*:
 
-        1. Only one candidate row — trivially unambiguous.
-        2. ``VideoFile.path`` basename matches the video filename.  Requires
-           ``VideoFile.path`` to be populated; call
-           ``VideoFile.update_entries()`` first if paths are null.
+        1. A lone candidate row is accepted directly, backfilling its ``path``
+           if currently null.
+        2. Otherwise the stored ``VideoFile.path`` is matched by *stem*, so a
+           raw ``file.1.h264`` (V1 ingest) resolves the DLC-converted
+           ``file.mp4`` — stems agree, suffixes differ.  Requires ``path`` to
+           be populated; call ``VideoFile.update_entries()`` first if null.
 
         Parameters
         ----------
         video_path : str
-            Path to the video file as it appears in the DLC config's
+            Path to the video as it appears in the DLC config's
             ``video_sets`` dict.
         restriction : any, optional
-            DataJoint restriction applied to ``VideoFile`` before fetching
-            candidates.  Defaults to no restriction — all rows.
-            Pass a dict such as ``{"nwb_file_name": "SC38_20230606_.nwb"}``
-            to scope the search to a specific session.
+            Restriction applied to VideoFile before fetching candidates.
+            Defaults to ``self.restriction`` (else all rows).
 
         Returns
         -------
         tuple[dict | None, list[dict]]
-            ``(pk_dict, [])`` when exactly one match is found;
-            ``(None, candidates)`` when the result is ambiguous or no rows
-            were fetched.  The pk_dict contains only the primary-key fields
+            ``(pk_dict, [])`` on a unique match; ``(None, candidates)`` when
+            empty or ambiguous.  ``pk_dict`` holds only the primary-key fields
             (``nwb_file_name``, ``epoch``, ``video_file_num``).
         """
         restriction = restriction or self.restriction or True
-
-        vf_rows = (self & restriction).fetch("KEY", "path", as_dict=True)
-        if not vf_rows:
+        candidates = (self & restriction).fetch("KEY", "path", as_dict=True)
+        if not candidates:
             return None, []
 
-        _pk_fields = ("nwb_file_name", "epoch", "video_file_num")
-
-        def _pk(row):
-            """Project a fetched row down to VideoFile's primary-key fields."""
-            return {k: row[k] for k in _pk_fields if k in row}
-
-        def _fill_path(row):
-            """Backfill VideoFile.path with video_path when currently null."""
+        # One candidate under the restriction — unambiguous. Record the DLC
+        # path against it when VideoFile.path is currently null. (update1 needs
+        # the full PK and must run on the base table, not a restriction.)
+        if len(candidates) == 1:
+            row = candidates[0]
             if not row.get("path") and video_path:
-                # update1 requires the full PK in the dict; call on the base
-                # table (self), not on a restricted expression.
-                self.update1({**_pk(row), "path": video_path})
+                self.update1({**self.dict_to_pk(row), "path": video_path})
+            return self.dict_to_pk(row), []
 
-        # Strategy 1 — only one VideoFile for this session: nothing to decide.
-        if len(vf_rows) == 1:
-            _fill_path(vf_rows[0])
-            return _pk(vf_rows[0]), []
-
-        vp_name = Path(video_path).name
-        vp_stem = Path(video_path).stem  # e.g. "20231007_SC1002_10_r5"
-
-        # Strategy 2 — basename match, with extension-agnostic fallback.
-        # V1 NWB ingestion stored raw paths (e.g. "file.1.h264") while DLC
-        # worked from mp4 conversions ("file.mp4").  The stems match but the
-        # suffixes differ.  Accept a VideoFile when its basename equals the DLC
-        # name exactly OR when it starts with the DLC stem followed by "." —
-        # i.e. "file.1.h264".startswith("file.") is True.
-        # Requires VideoFile.path to be populated; call update_entries() first
-        # if paths are null.
-        by_name = [
-            r
-            for r in vf_rows
-            if r.get("path")
-            and (
-                Path(r["path"]).name == vp_name
-                or Path(r["path"]).name.startswith(vp_stem + ".")
-            )
+        # Several candidates (multi-camera epoch) — match the stored path by
+        # stem.  ``name.startswith(stem + ".")`` covers an exact basename match
+        # too, so the raw-vs-converted suffix (h264/mp4) is handled uniformly.
+        stem = Path(video_path).stem
+        matched = [
+            row
+            for row in candidates
+            if row.get("path") and Path(row["path"]).name.startswith(stem + ".")
         ]
-        if len(by_name) == 1:
-            return _pk(by_name[0]), []
+        if len(matched) == 1:
+            return self.dict_to_pk(matched[0]), []
 
-        # All strategies exhausted — caller decides how to handle ambiguity.
-        # If ambiguity persists, run VideoFile.update_entries() to populate
-        # null path fields, then retry.
-        return None, vf_rows
+        return None, candidates
 
     def fetch_key_from_path(
         self, video_file_path: str, update_on_miss: bool = False

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1009,7 +1009,7 @@ class VideoFile(SpyglassMixin, dj.Imported):
 
         nwb_path = Nwbfile.get_abs_path(key["nwb_file_name"])
         nwbf = get_nwb_file(nwb_path)
-        nwb_video = nwbf.objects[video_info["video_file_object_id"]]
+        nwb_video = (cls & key).fetch_nwb()[0]["video_file"]
 
         # If the stored object ID resolves to a non-ImageSeries (e.g. a stale
         # reference to a ProcessingModule), search the NWB for ImageSeries.
@@ -1112,7 +1112,10 @@ class VideoFile(SpyglassMixin, dj.Imported):
             return None, []
 
         _pk_fields = ("nwb_file_name", "epoch", "video_file_num")
-        _pk = lambda r: {k: r[k] for k in _pk_fields if k in r}  # noqa: E731
+
+        def _pk(row):
+            """Project a fetched row down to VideoFile's primary-key fields."""
+            return {k: row[k] for k in _pk_fields if k in row}
 
         def _fill_path(row):
             """Backfill VideoFile.path with video_path when currently null."""

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1,7 +1,8 @@
-import pathlib
 import re
+from tqdm import tqdm
 from collections import defaultdict
 from functools import reduce
+from pathlib import Path
 from typing import Dict, List, Union
 
 import datajoint as dj
@@ -469,13 +470,18 @@ class VideoFile(SpyglassMixin, dj.Imported):
     ---
     camera_name: varchar(80)
     video_file_object_id: varchar(40)  # the object id of the file object
+    path = NULL: varchar(512)  # path to video file (if extracted)
     """
 
     _nwb_table = Nwbfile
     _timestamp_overlap_threshold = 0.9  # Min fraction of timestamps in epoch
 
     def _prepare_video_entry(
-        self, key, video_obj, cam_device_regex: str = r"camera_device (\d+)"
+        self,
+        key,
+        video_obj,
+        cam_device_regex: str = r"camera_device (\d+)",
+        file_idx=None,
     ):
         """Prepare a VideoFile entry dict for a given video object.
 
@@ -488,6 +494,9 @@ class VideoFile(SpyglassMixin, dj.Imported):
         cam_device_regex : str, optional
             Regular expression pattern to extract camera device number.
             Default: r"camera_device (\\d+)"
+        file_idx : int, optional
+            Index of which external file to use for multi-file ImageSeries.
+            If None, uses the first file (index 0). Default: None
 
         Returns
         -------
@@ -515,11 +524,34 @@ class VideoFile(SpyglassMixin, dj.Imported):
                 f"expected pattern '{cam_device_regex}'"
             )
 
+        # Resolve the on-disk path.
+        # Priority: absolute external_file path (stored at ingestion, most
+        # reliable) > video_dir / basename (fallback for older NWB files or
+        # those written without external_file populated).
+        ext_files = getattr(video_obj, "external_file", None) or []
+        resolved_path = None
+        if ext_files:
+            file_to_use = file_idx if file_idx is not None else 0
+            if file_to_use < len(ext_files):
+                selected_ext = Path(ext_files[file_to_use])
+                if selected_ext.is_absolute() and selected_ext.exists():
+                    # Use the stored absolute path directly.
+                    resolved_path = selected_ext.as_posix()
+                video_filename = selected_ext.name
+            else:  # pragma: no cover
+                video_filename = video_obj.name
+        else:  # pragma: no cover
+            video_filename = video_obj.name
+
+        if resolved_path is None:
+            resolved_path = (Path(video_dir) / video_filename).as_posix()
+
         return dict(
             key,
             video_file_num=int(match[1]),
             camera_name=camera_name,
             video_file_object_id=video_obj.object_id,
+            path=resolved_path,
         )
 
     def _validate_video_timestamps(self, video_obj, valid_times, key):
@@ -658,7 +690,9 @@ class VideoFile(SpyglassMixin, dj.Imported):
                 continue
 
             # This file segment matches the epoch - prepare VideoFile entry
-            entry = self._prepare_video_entry(key.copy(), video_obj)
+            entry = self._prepare_video_entry(
+                key.copy(), video_obj, file_idx=file_idx
+            )
             entries.append(entry)
 
         return entries, max_overlap_pct
@@ -818,20 +852,134 @@ class VideoFile(SpyglassMixin, dj.Imported):
 
         logger.warning("\n".join(msg_parts))
 
+    def _update_1_entry(self, row: dict) -> dict:
+        """Attempt to fill camera_name and/or path for a single VideoFile row.
+
+        Opens the NWB once and uses the result for both fields.  Path
+        resolution tries ``ImageSeries.external_file`` first, then falls back
+        to ``get_abs_path``.
+
+        Parameters
+        ----------
+        row : dict
+            VideoFile primary-key dict, possibly containing pre-fetched
+            ``camera_name`` and ``path`` values (null fields are the ones
+            that need updating).
+
+        Returns
+        -------
+        dict with keys:
+            ``needs_camera``, ``needs_path`` : bool — what was missing.
+            ``camera_updated``, ``path_updated`` : bool — what was filled.
+            ``nwb_error`` : str | None — NWB fetch failure message.
+            ``path_error`` : str | None — path lookup failure message.
+        """
+        needs_camera = not row.get("camera_name")
+        needs_path = not row.get("path")
+        status = dict(
+            needs_camera=needs_camera,
+            needs_path=needs_path,
+            camera_updated=False,
+            path_updated=False,
+            nwb_error=None,
+            path_error=None,
+        )
+
+        if not (needs_camera or needs_path):
+            return status
+
+        try:
+            video_nwb = (self & row).fetch_nwb()
+        except (FileNotFoundError, ValueError, dj.DataJointError) as e:
+            status["nwb_error"] = str(e)
+            return status
+
+        if len(video_nwb) != 1:
+            raise ValueError(
+                f"Expected 1 video file per entry, got {len(video_nwb)}"
+            )
+        video_file = video_nwb[0]["video_file"]
+
+        if needs_camera:
+            row["camera_name"] = video_file.device.camera_name
+            status["camera_updated"] = True
+
+        if needs_path:
+            # Source 1: external_file in the NWB ImageSeries — most direct.
+            path_found = None
+            ext_files = getattr(video_file, "external_file", None)
+            if not isinstance(ext_files, (list, tuple)):
+                ext_files = []
+            for ext in ext_files:
+                p = Path(ext)
+                if p.is_absolute() and p.exists():
+                    path_found = p.as_posix()
+                    break
+
+            # Source 2: SPYGLASS_VIDEO_DIR lookup.
+            if path_found is None:
+                try:
+                    path_found = self.get_abs_path(row)
+                except (FileNotFoundError, dj.DataJointError) as e:
+                    status["path_error"] = str(e)
+
+            if path_found is not None:
+                row["path"] = path_found
+                status["path_updated"] = True
+
+        self.update1(row=row)
+        return status
+
     @classmethod
-    def update_entries(cls, restrict=True):
-        """Update the camera_name field for all entries in the table."""
-        existing_entries = (cls & restrict).fetch("KEY")
-        for row in existing_entries:
-            if (cls & row).fetch1("camera_name"):
-                continue
-            video_nwb = (cls & row).fetch_nwb()[0]
-            if len(video_nwb) != 1:
-                raise ValueError(
-                    f"Expecting 1 video file per entry. {len(video_nwb)} found"
+    def update_entries(cls, restrict=True, display_progress=True):
+        """Update the camera_name and path fields for all null entries.
+
+        Delegates per-entry work to :meth:`_update_1_entry` and aggregates
+        the results into a summary log.
+        """
+        instance = cls()
+        query = instance & restrict & "camera_name IS NULL OR path IS NULL"
+        existing_entries = query.fetch("KEY")
+        total = len(existing_entries)
+        updated_camera = updated_path = skipped_camera = skipped_path = 0
+        failed_path = []
+
+        for row in tqdm(
+            existing_entries,
+            desc="Updating VideoFile entries",
+            disable=not display_progress,
+        ):
+            s = instance._update_1_entry(row)
+
+            if s["nwb_error"]:
+                instance._warn_msg(
+                    f"Could not fetch NWB for {row}: {s['nwb_error']}"
                 )
-            row["camera_name"] = video_nwb[0]["video_file"].device.camera_name
-            cls.update1(row=row)
+
+            updated_camera += s["camera_updated"]
+            skipped_camera += s["needs_camera"] and not s["camera_updated"]
+
+            updated_path += s["path_updated"]
+            skipped_path += (
+                s["needs_path"]
+                and not s["path_updated"]
+                and not s["path_error"]
+            )
+            if s["path_error"]:
+                failed_path.append((row, s["path_error"]))
+
+        msg = [
+            "VideoFile.update_entries:",
+            f"  entries checked: {total}",
+            f"  updated/skipped camera_name: {updated_camera}/{skipped_camera}",
+            f"  updated/skipped/failed path: {updated_path}/{skipped_path}/"
+            + f"{len(failed_path)}",
+        ]
+        if failed_path:
+            msg.append("  Failed path lookups:")
+            for row, err in failed_path:
+                msg.append(f"    {row}: {err}")
+        logger.info("\n".join(msg))
 
     @classmethod
     def get_abs_path(cls, key: Dict):
@@ -850,21 +998,201 @@ class VideoFile(SpyglassMixin, dj.Imported):
         nwb_video_file_abspath : str
             The absolute path for the given file name.
         """
-        video_path_obj = pathlib.Path(video_dir)
         video_info = (cls & key).fetch1()
+        video_path_obj = Path(video_dir)
+
+        # If the path was stored during make(), use it directly.
+        if stored_path := video_info.get("path"):
+            stored = Path(stored_path)
+            if stored.exists():
+                return stored.as_posix()
+
         nwb_path = Nwbfile.get_abs_path(key["nwb_file_name"])
         nwbf = get_nwb_file(nwb_path)
         nwb_video = nwbf.objects[video_info["video_file_object_id"]]
+
+        # If the stored object ID resolves to a non-ImageSeries (e.g. a stale
+        # reference to a ProcessingModule), search the NWB for ImageSeries.
+        if not isinstance(nwb_video, pynwb.image.ImageSeries):
+            image_series = [
+                obj
+                for obj in nwbf.objects.values()
+                if isinstance(obj, pynwb.image.ImageSeries)
+            ]
+            if not image_series:
+                raise FileNotFoundError(
+                    f"No ImageSeries found in {key['nwb_file_name']}"
+                )
+            nwb_video = image_series[0]
+
         video_filename = nwb_video.name
-        # see if the file exists and is stored in the base analysis dir
-        nwb_video_file_abspath = pathlib.Path(video_path_obj / video_filename)
+
+        # Try the NWB object name first (often equals the real filename)
+        nwb_video_file_abspath = Path(video_path_obj / video_filename)
         if nwb_video_file_abspath.exists():
             return nwb_video_file_abspath.as_posix()
-        else:
-            raise FileNotFoundError(
-                f"video file with filename: {video_filename} "
-                f"does not exist in {video_path_obj}/"
+
+        # Fallback: check external_file entries (actual on-disk video paths)
+        for ext_file in getattr(nwb_video, "external_file", None) or []:
+            ext = Path(ext_file)
+            if ext.is_absolute() and ext.exists():
+                return ext.as_posix()
+            abs_ext = video_path_obj / ext.name
+            if abs_ext.exists():
+                return abs_ext.as_posix()
+
+        raise FileNotFoundError(
+            f"video file with filename: {video_filename} "
+            f"does not exist in {video_path_obj}/"
+        )
+
+    @classmethod
+    def get_abs_paths(cls, key: Dict) -> list:
+        """Return absolute paths for all VideoFile rows matching *key*.
+
+        Unlike :meth:`get_abs_path`, *key* may be a partial primary key
+        (e.g. ``{nwb_file_name, epoch}`` without ``video_file_num``).  Every
+        matching row is resolved and returned as a list, which handles
+        multi-camera epochs gracefully.
+
+        Parameters
+        ----------
+        key : dict
+            Partial or full primary key for VideoFile.
+
+        Returns
+        -------
+        list of str
+            Absolute paths for all matching video files.
+
+        Raises
+        ------
+        ValueError
+            If no VideoFile rows match *key*.
+        """
+        row_keys = (cls & key).fetch("KEY")
+        if not row_keys:
+            raise ValueError(f"No VideoFile rows found for key: {key}")
+        return [cls.get_abs_path(k) for k in row_keys]
+
+    def _narrow_key_lookup(self, video_path: str, restriction=None) -> tuple:
+        """Select a single VideoFile PK for *video_path* under *restriction*.
+
+        Fetches ``(KEY, path)`` rows from ``VideoFile & restriction``, then
+        tries two strategies in order of decreasing reliability:
+
+        1. Only one candidate row — trivially unambiguous.
+        2. ``VideoFile.path`` basename matches the video filename.  Requires
+           ``VideoFile.path`` to be populated; call
+           ``VideoFile.update_entries()`` first if paths are null.
+
+        Parameters
+        ----------
+        video_path : str
+            Path to the video file as it appears in the DLC config's
+            ``video_sets`` dict.
+        restriction : any, optional
+            DataJoint restriction applied to ``VideoFile`` before fetching
+            candidates.  Defaults to no restriction — all rows.
+            Pass a dict such as ``{"nwb_file_name": "SC38_20230606_.nwb"}``
+            to scope the search to a specific session.
+
+        Returns
+        -------
+        tuple[dict | None, list[dict]]
+            ``(pk_dict, [])`` when exactly one match is found;
+            ``(None, candidates)`` when the result is ambiguous or no rows
+            were fetched.  The pk_dict contains only the primary-key fields
+            (``nwb_file_name``, ``epoch``, ``video_file_num``).
+        """
+        restriction = restriction or self.restriction or True
+
+        vf_rows = (self & restriction).fetch("KEY", "path", as_dict=True)
+        if not vf_rows:
+            return None, []
+
+        _pk_fields = ("nwb_file_name", "epoch", "video_file_num")
+        _pk = lambda r: {k: r[k] for k in _pk_fields if k in r}  # noqa: E731
+
+        def _fill_path(row):
+            """Backfill VideoFile.path with video_path when currently null."""
+            if not row.get("path") and video_path:
+                # update1 requires the full PK in the dict; call on the base
+                # table (self), not on a restricted expression.
+                self.update1({**_pk(row), "path": video_path})
+
+        # Strategy 1 — only one VideoFile for this session: nothing to decide.
+        if len(vf_rows) == 1:
+            _fill_path(vf_rows[0])
+            return _pk(vf_rows[0]), []
+
+        vp_name = Path(video_path).name
+        vp_stem = Path(video_path).stem  # e.g. "20231007_SC1002_10_r5"
+
+        # Strategy 2 — basename match, with extension-agnostic fallback.
+        # V1 NWB ingestion stored raw paths (e.g. "file.1.h264") while DLC
+        # worked from mp4 conversions ("file.mp4").  The stems match but the
+        # suffixes differ.  Accept a VideoFile when its basename equals the DLC
+        # name exactly OR when it starts with the DLC stem followed by "." —
+        # i.e. "file.1.h264".startswith("file.") is True.
+        # Requires VideoFile.path to be populated; call update_entries() first
+        # if paths are null.
+        by_name = [
+            r
+            for r in vf_rows
+            if r.get("path")
+            and (
+                Path(r["path"]).name == vp_name
+                or Path(r["path"]).name.startswith(vp_stem + ".")
             )
+        ]
+        if len(by_name) == 1:
+            return _pk(by_name[0]), []
+
+        # All strategies exhausted — caller decides how to handle ambiguity.
+        # If ambiguity persists, run VideoFile.update_entries() to populate
+        # null path fields, then retry.
+        return None, vf_rows
+
+    def fetch_key_from_path(
+        self, video_file_path: str, update_on_miss: bool = False
+    ) -> Dict:
+        """Return the primary key for a given video file path.
+
+        Parameters
+        ----------
+        video_file_path : str
+            The path to the video file.
+        update_on_miss : bool
+            If True and the path is not found in the table, call
+            ``update_entries()`` to refresh null-path rows, then retry.
+            Defaults to False to avoid the O(N) scan on every read. Call
+            ``VideoFile.update_entries()`` explicitly before this method if
+            you expect newly-ingested paths to be present.
+
+        Returns
+        -------
+        key : dict
+            The primary key for the given video file path.
+        """
+        video_path = Path(video_file_path).resolve()
+
+        if not video_path.exists():
+            raise FileNotFoundError(f"File {video_path} does not exist.")
+
+        query = self & {"path": video_path.as_posix()}
+
+        if not query and update_on_miss:
+            # Caller opted in — refresh null-path entries then retry once
+            self.update_entries()
+            query = self & {"path": video_path.as_posix()}
+
+        if len(query) != 1:
+            raise ValueError(
+                f"No unique entry in VideoFile for {video_path}: \n{query}"
+            )
+
+        return query.fetch1("KEY")
 
 
 @schema
@@ -878,10 +1206,6 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
     # #849 - Insert null to avoid rerun
 
     def make(self, key):
-        """Make without transaction"""
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         # Find correspondence between pos valid times names and epochs. Use
         # epsilon to tolerate small differences in epoch boundaries across
         # epoch/pos intervals
@@ -1007,7 +1331,7 @@ def convert_epoch_interval_name_to_position_interval_name(
     if populate_missing and (no_entries or null_entry):
         if null_entry:
             pos_query.delete(safemode=False)  # no prompt
-        PositionIntervalMap()._no_transaction_make(key)
+        PositionIntervalMap().make(key)
         pos_query = PositionIntervalMap & key
 
     if pos_query.fetch(pos_str)[0] == "":

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -938,7 +938,7 @@ class VideoFile(SpyglassMixin, dj.Imported):
         the results into a summary log.
         """
         instance = cls()
-        query = instance & restrict & "camera_name IS NULL OR path IS NULL"
+        query = instance & restrict & "(camera_name IS NULL OR path IS NULL)"
         existing_entries = query.fetch("KEY")
         total = len(existing_entries)
         updated_camera = updated_path = skipped_camera = skipped_path = 0

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -53,6 +53,20 @@ class Session(SpyglassIngestion, dj.Imported):
             "subject": {"subject_id": "subject_id"},
         }
 
+    @property
+    def with_date_str(self):
+        """Project session_date_str (YYYYMMDD) from session_start_time.
+
+        Returns a query expression with the primary key plus a computed
+        ``session_date_str`` column, useful for date-based restriction::
+
+            Session().with_date_str & {"session_date_str": "20230101"}
+        """
+        return (self & self.restriction).proj(
+            subject_id="subject_id",
+            session_date_str="DATE_FORMAT(session_start_time, '%%Y%%m%%d')",
+        )
+
     class DataAcquisitionDevice(SpyglassIngestion, dj.Part):  # noqa: F811
         definition = """
         # Part table linking Session to multiple DataAcquisitionDevice entries.

--- a/src/spyglass/directory_schema.json
+++ b/src/spyglass/directory_schema.json
@@ -23,7 +23,7 @@
       "storage": "kachery_storage",
       "temp": "tmp"
     },
-    "dlc": {
+    "pose": {
       "project": "projects",
       "video": "video",
       "output": "output"

--- a/src/spyglass/settings.py
+++ b/src/spyglass/settings.py
@@ -161,7 +161,7 @@ class SpyglassConfig:
         dj_custom = dj.config.get("custom", {})
         dj_spyglass = dj_custom.get("spyglass_dirs", {})
         dj_kachery = dj_custom.get("kachery_dirs", {})
-        dj_dlc = dj_custom.get("dlc_dirs", {})
+        dj_pose = dj_custom.get("pose_dirs", {})
         dj_moseq = dj_custom.get("moseq_dirs", {})
 
         self._debug_mode = dj_custom.get("debug_mode", False)
@@ -201,13 +201,13 @@ class SpyglassConfig:
             self.load_failed = True
             return
 
-        self._dlc_base = (
-            dj_dlc.get("base")
+        self._pose_base = (
+            dj_pose.get("base")
             or os.environ.get("DLC_BASE_DIR")
             or os.environ.get("DLC_PROJECT_PATH", "").split("projects")[0]
             or str(Path(resolved_base) / "deeplabcut")
         )
-        Path(self._dlc_base).mkdir(parents=True, exist_ok=True)
+        Path(self._pose_base).mkdir(parents=True, exist_ok=True)
 
         self._moseq_base = (
             dj_moseq.get("base")
@@ -218,11 +218,11 @@ class SpyglassConfig:
 
         config_dirs = {"SPYGLASS_BASE_DIR": str(resolved_base)}
         source_config_lookup = {
-            "dlc": dj_dlc,
+            "pose": dj_pose,
             "moseq": dj_moseq,
             "kachery": dj_kachery,
         }
-        base_lookup = {"dlc": self._dlc_base, "moseq": self._moseq_base}
+        base_lookup = {"pose": self._pose_base, "moseq": self._moseq_base}
         for prefix, dirs in self.relative_dirs.items():
             this_base = base_lookup.get(prefix, resolved_base)
             for dir, dir_str in dirs.items():
@@ -526,11 +526,11 @@ class SpyglassConfig:
                     ),
                     "temp": self.config.get(self.dir_to_var("temp", "kachery")),
                 },
-                "dlc_dirs": {
-                    "base": self._dlc_base,
-                    "project": self.dlc_project_dir,
-                    "video": self.dlc_video_dir,
-                    "output": self.dlc_output_dir,
+                "pose_dirs": {
+                    "base": str(self._pose_base),
+                    "project": self.pose_project_dir,
+                    "video": self.pose_video_dir,
+                    "output": self.pose_output_dir,
                 },
                 "moseq_dirs": {
                     "base": self._moseq_base,
@@ -610,19 +610,34 @@ class SpyglassConfig:
         return self._test_mode
 
     @property
+    def pose_project_dir(self) -> str:
+        """Pose project directory as a string."""
+        return self.config.get(self.dir_to_var("project", "pose"))
+
+    @property
+    def pose_video_dir(self) -> str:
+        """Pose video directory as a string."""
+        return self.config.get(self.dir_to_var("video", "pose"))
+
+    @property
+    def pose_output_dir(self) -> str:
+        """Pose output directory as a string."""
+        return self.config.get(self.dir_to_var("output", "pose"))
+
+    @property
     def dlc_project_dir(self) -> str:
-        """DLC project directory as a string."""
-        return self.config.get(self.dir_to_var("project", "dlc"))
+        """DLC project directory as a string (deprecated, use pose_project_dir)."""
+        return self.pose_project_dir
 
     @property
     def dlc_video_dir(self) -> str:
-        """DLC video directory as a string."""
-        return self.config.get(self.dir_to_var("video", "dlc"))
+        """DLC video directory as a string (deprecated, use pose_video_dir)."""
+        return self.pose_video_dir
 
     @property
     def dlc_output_dir(self) -> str:
-        """DLC output directory as a string."""
-        return self.config.get(self.dir_to_var("output", "dlc"))
+        """DLC output directory as a string (deprecated, use pose_output_dir)."""
+        return self.pose_output_dir
 
     @property
     def moseq_project_dir(self) -> str:
@@ -652,6 +667,12 @@ if sg_config.load_failed:  # Failed to load
     waveforms_dir = None
     video_dir = None
     export_dir = None
+    pose_project_dir = None
+    pose_video_dir = None
+    pose_output_dir = None
+    pose_project_dir = None
+    pose_video_dir = None
+    pose_output_dir = None
     dlc_project_dir = None
     dlc_video_dir = None
     dlc_output_dir = None
@@ -671,6 +692,9 @@ else:
     debug_mode = sg_config.debug_mode
     test_mode = sg_config.test_mode
     prepopulate = config.get("prepopulate", False)
+    pose_project_dir = sg_config.pose_project_dir
+    pose_video_dir = sg_config.pose_video_dir
+    pose_output_dir = sg_config.pose_output_dir
     dlc_project_dir = sg_config.dlc_project_dir
     dlc_video_dir = sg_config.dlc_video_dir
     dlc_output_dir = sg_config.dlc_output_dir

--- a/src/spyglass/settings.py
+++ b/src/spyglass/settings.py
@@ -670,9 +670,6 @@ if sg_config.load_failed:  # Failed to load
     pose_project_dir = None
     pose_video_dir = None
     pose_output_dir = None
-    pose_project_dir = None
-    pose_video_dir = None
-    pose_output_dir = None
     dlc_project_dir = None
     dlc_video_dir = None
     dlc_output_dir = None

--- a/src/spyglass/utils/__init__.py
+++ b/src/spyglass/utils/__init__.py
@@ -1,9 +1,9 @@
 from spyglass.utils.dj_merge_tables import _Merge
 from spyglass.utils.dj_mixin import (
     SpyglassAnalysis,
+    SpyglassIngestion,
     SpyglassMixin,
     SpyglassMixinPart,
-    SpyglassIngestion,
 )
 from spyglass.utils.logging import logger
 

--- a/src/spyglass/utils/logging.py
+++ b/src/spyglass/utils/logging.py
@@ -5,7 +5,109 @@ import sys
 
 import datajoint as dj
 
+
+class SpyglassLogger(logging.Logger):
+    """Custom logger with test-mode-aware methods.
+
+    Provides methods that automatically adjust log level based on test mode,
+    matching the behavior of BaseMixin._info_msg, _warn_msg, _error_msg.
+    """
+
+    def _get_test_mode(self) -> bool:
+        """Get test mode setting from spyglass config.
+
+        Returns True if in test mode, False otherwise.
+        Used to determine whether to use debug logging during tests.
+        """
+        try:
+            from spyglass.settings import config as sg_config
+
+            return sg_config.get("test_mode", False)
+        except ImportError:  # pragma: no cover
+            return False
+
+    def info_msg(self, msg: str) -> None:
+        """Log info message, but debug if in test mode.
+
+        Quiets logs during testing, but preserves user experience during use.
+        Equivalent to BaseMixin._info_msg but accessible to static methods.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log
+        """
+        log_func = self.debug if self._get_test_mode() else self.info
+        log_func(msg)
+
+    def warn_msg(self, msg: str) -> None:
+        """Log warning message, but debug if in test mode.
+
+        Quiets logs during testing, but preserves user experience during use.
+        Equivalent to BaseMixin._warn_msg but accessible to static methods.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log
+        """
+        log_func = self.debug if self._get_test_mode() else self.warning
+        log_func(msg)
+
+    def error_msg(self, msg: str) -> None:
+        """Log error message, but debug if in test mode.
+
+        Quiets logs during testing, but preserves user experience during use.
+        Equivalent to BaseMixin._error_msg but accessible to static methods.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log
+        """
+        log_func = self.debug if self._get_test_mode() else self.error
+        log_func(msg)
+
+
+# Register via getLogger so the instance is in the hierarchy (caplog works)
+logging.setLoggerClass(SpyglassLogger)
 logger = logging.getLogger(__name__.split(".")[0])
+logging.setLoggerClass(logging.Logger)
+
+
+# Provide helper functions for easy access to logger methods
+def info_msg(msg: str) -> None:
+    """Log info message using Spyglass logger.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log
+    """
+    logger.info_msg(msg)
+
+
+def warn_msg(msg: str) -> None:
+    """Log warning message using Spyglass logger.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log
+    """
+    logger.warn_msg(msg)
+
+
+def error_msg(msg: str) -> None:
+    """Log error message using Spyglass logger.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log
+    """
+    logger.error_msg(msg)
+
 
 log_level = dj.config.get("loglevel", "INFO").upper()
 

--- a/src/spyglass/utils/logging.py
+++ b/src/spyglass/utils/logging.py
@@ -69,10 +69,13 @@ class SpyglassLogger(logging.Logger):
         log_func(msg)
 
 
-# Register via getLogger so the instance is in the hierarchy (caplog works)
+# Register via getLogger so the instance is in the hierarchy (caplog works).
+# Save and restore the prior logger class so we don't clobber an
+# application-configured custom Logger class.
+_prev_logger_class = logging.getLoggerClass()
 logging.setLoggerClass(SpyglassLogger)
 logger = logging.getLogger(__name__.split(".")[0])
-logging.setLoggerClass(logging.Logger)
+logging.setLoggerClass(_prev_logger_class)
 
 
 # Provide helper functions for easy access to logger methods

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -414,7 +414,7 @@ def get_valid_intervals(
 
     if total_time < min_valid_len:
         half_total_time = total_time / 2
-        logger.warning(
+        logger.warn_msg(
             f"Setting minimum valid interval to {half_total_time:.4f}"
         )
         min_valid_len = half_total_time

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -1,5 +1,3 @@
-# pylint: disable=protected-access
-
 import pytest
 from pandas import DataFrame
 
@@ -15,7 +13,7 @@ def test_invalid_interval(pos_src):
 
 def test_invalid_epoch_num(common):
     """Test invalid epoch num"""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid interval name"):
         common.PositionSource.get_epoch_num("invalid_epoch_num")
 
 
@@ -27,8 +25,12 @@ def test_valid_epoch_num(common):
 
 @pytest.mark.slow
 def test_pos_source_make(common):
-    """Test custom populate"""
+    """Test custom populate inserts sources tagged 'imported'."""
     common.PositionSource().make(common.Session())
+    sources = set(common.PositionSource().fetch("source"))
+    assert sources == {
+        "imported"
+    }, "PositionSource.make should insert rows with source='imported'"
 
 
 def test_pos_source_make_invalid(common):
@@ -84,9 +86,12 @@ def test_populate_state_script(common, pop_state_script):
 
 
 def test_videofile_update_entries(common):
-    """Test update entries"""
-    key = common.VideoFile().fetch(as_dict=True)[0]
+    """Test update entries leaves camera_name populated for the row."""
+    key = common.VideoFile().fetch("KEY", as_dict=True)[0]
     common.VideoFile().update_entries(key)
+    assert (common.VideoFile() & key).fetch1(
+        "camera_name"
+    ), "update_entries should leave camera_name populated"
 
 
 def test_fetch_key_from_path_no_side_effect(common, tmp_path):
@@ -188,8 +193,11 @@ def test_prepare_video_entry_with_external_file(common):
 
         result = video_file._prepare_video_entry(key, mock_video)
 
-        expected_filename = Path("file1.mp4").name
-        assert expected_filename in result["path"]
+        # "camera_device 1" -> video_file_num 1; first external file used
+        assert result["video_file_num"] == 1
+        assert result["camera_name"] == "test_camera"
+        assert result["video_file_object_id"] == "test_object_id"
+        assert result["path"].endswith("/" + Path("file1.mp4").name)
 
 
 def test_prepare_video_entry_with_file_idx(common):
@@ -219,12 +227,14 @@ def test_prepare_video_entry_with_file_idx(common):
 
         result = video_file._prepare_video_entry(key, mock_video, file_idx=1)
 
-        expected_filename = Path("file2.mp4").name
-        assert expected_filename in result["path"]
+        # "camera_device 2" -> num 2; file_idx=1 selects the second file
+        assert result["video_file_num"] == 2
+        assert result["path"].endswith("/" + Path("file2.mp4").name)
 
 
 def test_prepare_video_entry_with_empty_external_file(common):
     """Test _prepare_video_entry with empty external_file list."""
+    from pathlib import Path
     from unittest.mock import MagicMock, Mock
 
     # Create mock video object with empty external_file
@@ -248,8 +258,9 @@ def test_prepare_video_entry_with_empty_external_file(common):
 
         result = video_file._prepare_video_entry(key, mock_video)
 
-        # Should use video object name as fallback
-        assert "fallback_video_name" in result["path"]
+        # No external_file -> falls back to the video object's own name
+        assert result["video_file_num"] == 3
+        assert result["path"].endswith("/" + Path("fallback_video_name").name)
 
 
 # Additional comprehensive tests for common_behav.py coverage improvement
@@ -332,8 +343,9 @@ def test_prepare_video_entry_file_idx_out_of_range(common):
         # Request file_idx=2 when only 1 file exists
         result = video_file._prepare_video_entry(key, mock_video, file_idx=2)
 
-        # Should fallback to video object name
-        assert "fallback_name" in result["path"]
+        # Out-of-range idx -> falls back to the video object's own name
+        assert result["video_file_num"] == 5
+        assert result["path"].endswith("/fallback_name")
 
 
 def test_validate_video_timestamps_single_file(common):
@@ -464,8 +476,8 @@ def test_validate_multifile_timestamps_no_valid_segments(common):
 
 
 def test_videofile_make_no_videos(common):
-    """Test VideoFile.make when no ImageSeries found in NWB file."""
-    from unittest.mock import Mock, patch
+    """Test VideoFile.make warns and returns when NWB has no ImageSeries."""
+    from unittest.mock import Mock, PropertyMock, patch
 
     # Mock NWB file with no ImageSeries objects
     mock_nwbf = Mock()
@@ -474,20 +486,32 @@ def test_videofile_make_no_videos(common):
     video_file = common.VideoFile()
 
     with (
+        patch.object(
+            type(video_file.connection),
+            "in_transaction",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
         patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
         patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
+        patch.object(video_file, "_warn_msg") as mock_warn,
     ):
 
         mock_get_nwb.return_value = mock_nwbf
         mock_get_path.return_value = "/fake/path.nwb"
 
-        # Should not raise, just return early with warning
         video_file.make({"nwb_file_name": "test.nwb"})
 
+    # Empty videos dict -> warns about the missing data interface and returns
+    mock_warn.assert_called_once()
+    assert (
+        "No video data interface found in test.nwb" in mock_warn.call_args[0][0]
+    )
 
-def test_videofile_make_camera_device_error(common):
-    """Test VideoFile.make with camera device KeyError during processing."""
-    from unittest.mock import Mock, patch
+
+def test_videofile_make_camera_device_error(common, caplog):
+    """Test VideoFile.make reports a missing-camera KeyError, not raises."""
+    from unittest.mock import Mock, PropertyMock, patch
 
     import pynwb
 
@@ -505,6 +529,12 @@ def test_videofile_make_camera_device_error(common):
     video_file = common.VideoFile()
 
     with (
+        patch.object(
+            type(video_file.connection),
+            "in_transaction",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
         patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
         patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
         patch.object(common.TaskEpoch, "__and__") as mock_task_epoch,
@@ -522,13 +552,17 @@ def test_videofile_make_camera_device_error(common):
         # Simulate KeyError from _validate_video_timestamps
         mock_validate.side_effect = KeyError("Camera not found")
 
-        # Should handle error gracefully
         video_file.make({"nwb_file_name": "test.nwb"})
 
+    # KeyError is caught and surfaced via the partial-import report
+    assert "VideoFile Partial Import" in caplog.text
+    assert "Missing camera devices" in caplog.text
+    assert "missing_camera" in caplog.text
 
-def test_videofile_make_unexpected_error(common):
-    """Test VideoFile.make with unexpected error during processing."""
-    from unittest.mock import Mock, patch
+
+def test_videofile_make_unexpected_error(common, caplog):
+    """Test VideoFile.make reports an unexpected error, not raises."""
+    from unittest.mock import Mock, PropertyMock, patch
 
     import pynwb
 
@@ -543,6 +577,12 @@ def test_videofile_make_unexpected_error(common):
     video_file = common.VideoFile()
 
     with (
+        patch.object(
+            type(video_file.connection),
+            "in_transaction",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
         patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
         patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
         patch.object(common.TaskEpoch, "__and__") as mock_task_epoch,
@@ -560,8 +600,12 @@ def test_videofile_make_unexpected_error(common):
         # Simulate unexpected error
         mock_validate.side_effect = RuntimeError("Unexpected error")
 
-        # Should handle error gracefully
         video_file.make({"nwb_file_name": "test.nwb"})
+
+    # RuntimeError is caught and surfaced under the "Other errors" section
+    assert "VideoFile Partial Import" in caplog.text
+    assert "Other errors" in caplog.text
+    assert "RuntimeError: Unexpected error" in caplog.text
 
 
 def test_videofile_report_partial_import(common, caplog):
@@ -771,14 +815,8 @@ def test_videofile_update_entries_with_null_values(common):
         assert mock_update1.call_count == 2
 
 
-def test_position_source_invalid_interval_name(pos_src):
-    """Test PositionSource with invalid interval name formats."""
-    with pytest.raises(ValueError, match="Invalid interval name"):
-        pos_src.get_epoch_num("not_an_epoch_name")
-
-
 def test_position_source_insert_from_nwbfile(common):
-    """Test PositionSource.insert_from_nwbfile with no spatial series."""
+    """Test insert_from_nwbfile logs and skips when no spatial series."""
     from unittest.mock import Mock, patch
 
     # Mock NWB file with no spatial series
@@ -789,36 +827,14 @@ def test_position_source_insert_from_nwbfile(common):
         patch(
             "spyglass.common.common_behav.get_all_spatial_series"
         ) as mock_get_spatial,
+        patch.object(common.PositionSource, "_info_msg") as mock_info,
     ):
 
         mock_get_nwb.return_value = mock_nwbf
         mock_get_spatial.return_value = None  # No spatial series found
 
-        # Should not raise, just log info and return
         common.PositionSource.insert_from_nwbfile("test.nwb")
 
-    with (
-        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
-        patch(
-            "spyglass.common.common_behav.get_all_spatial_series"
-        ) as mock_get_spatial,
-    ):
-
-        mock_get_nwb.return_value = mock_nwbf
-        mock_get_spatial.return_value = None  # No spatial series found
-
-        # Should not raise, just log info and return
-        common.PositionSource.insert_from_nwbfile("test.nwb")
-
-    with (
-        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
-        patch(
-            "spyglass.common.common_behav.get_all_spatial_series"
-        ) as mock_get_spatial,
-    ):
-
-        mock_get_nwb.return_value = mock_nwbf
-        mock_get_spatial.return_value = None  # No spatial series found
-
-        # Should not raise, just log info and return
-        common.PositionSource.insert_from_nwbfile("test.nwb")
+    # None spatial series -> the skip branch logs and returns without inserting
+    mock_info.assert_called_once()
+    assert "No position data found in test.nwb" in mock_info.call_args[0][0]

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -655,35 +655,27 @@ def test_videofile_get_abs_path_with_stored_path(common):
 
 
 def test_videofile_get_abs_path_fallback_external_file(common):
-    """Test VideoFile.get_abs_path fallback to external_file when object name fails."""
+    """get_abs_path falls back to the ImageSeries external_file path."""
     from pathlib import Path
-    from unittest.mock import MagicMock, Mock, patch
+    from unittest.mock import Mock, patch
 
     import pynwb
 
-    # Mock scenario where stored path doesn't exist, object name doesn't exist,
-    # but external_file path exists
+    # Stored path absent; object-name path missing; external_file resolves.
     video_info = {"path": None, "video_file_object_id": "obj_123"}
 
-    # Mock ImageSeries with external_file
     mock_video = Mock(spec=pynwb.image.ImageSeries)
     mock_video.name = "nonexistent_video.mp4"
     mock_video.external_file = ["/real/external/path.mp4"]
 
-    mock_nwbf = Mock()
-    mock_nwbf.objects = MagicMock()
-    mock_nwbf.objects.__getitem__.return_value = mock_video
-
     with (
         patch.object(common.VideoFile, "__and__") as mock_query,
-        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
-        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
         patch.object(Path, "exists") as mock_exists,
     ):
-
         mock_query.return_value.fetch1.return_value = video_info
-        mock_get_abs_path.return_value = "/nwb/path.nwb"
-        mock_get_nwb.return_value = mock_nwbf
+        mock_query.return_value.fetch_nwb.return_value = [
+            {"video_file": mock_video}
+        ]
 
         # Object-name path misses, then absolute external path resolves.
         mock_exists.side_effect = [False, True]
@@ -693,74 +685,29 @@ def test_videofile_get_abs_path_fallback_external_file(common):
         assert result == "/real/external/path.mp4"
 
 
-def test_videofile_get_abs_path_non_image_series_fallback(common):
-    """Test VideoFile.get_abs_path when object_id isn't ImageSeries."""
+def test_videofile_get_abs_path_missing_raises(common):
+    """get_abs_path raises FileNotFoundError when no path resolves."""
     from pathlib import Path
-    from unittest.mock import MagicMock, Mock, patch
+    from unittest.mock import Mock, patch
 
     import pynwb
 
-    video_info = {"path": None, "video_file_object_id": "stale_obj_123"}
-
-    # Mock stale object that's not an ImageSeries
-    mock_stale_obj = Mock()  # Not an ImageSeries
-
-    # Mock real ImageSeries to fallback to
-    mock_video = Mock(spec=pynwb.image.ImageSeries)
-    mock_video.name = "real_video.mp4"
-    mock_video.external_file = ["real_video.mp4"]
-
-    mock_nwbf = Mock()
-    mock_nwbf.objects = MagicMock()
-    mock_nwbf.objects.__getitem__.return_value = mock_stale_obj
-    mock_nwbf.objects.values.return_value = [mock_stale_obj, mock_video]
-
-    with (
-        patch.object(common.VideoFile, "__and__") as mock_query,
-        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
-        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
-        patch.object(Path, "exists") as mock_exists,
-    ):
-
-        mock_query.return_value.fetch1.return_value = video_info
-        mock_get_abs_path.return_value = "/nwb/path.nwb"
-        mock_get_nwb.return_value = mock_nwbf
-
-        # Fallback object-name path misses, then the external-file lookup under
-        # video_dir resolves.
-        mock_exists.side_effect = [False, True]
-
-        result = common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
-
-        # Should use the real ImageSeries object, not the stale reference
-        assert "real_video.mp4" in result
-
-
-def test_videofile_get_abs_path_no_image_series_error(common):
-    """Test VideoFile.get_abs_path when no ImageSeries found in NWB."""
-    from unittest.mock import MagicMock, Mock, patch
-
     video_info = {"path": None, "video_file_object_id": "obj_123"}
 
-    # Mock non-ImageSeries object
-    mock_other_obj = Mock()
-
-    mock_nwbf = Mock()
-    mock_nwbf.objects = MagicMock()
-    mock_nwbf.objects.__getitem__.return_value = mock_other_obj
-    mock_nwbf.objects.values.return_value = [mock_other_obj]
+    mock_video = Mock(spec=pynwb.image.ImageSeries)
+    mock_video.name = "missing_video.mp4"
+    mock_video.external_file = []
 
     with (
         patch.object(common.VideoFile, "__and__") as mock_query,
-        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
-        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(Path, "exists", return_value=False),
     ):
-
         mock_query.return_value.fetch1.return_value = video_info
-        mock_get_abs_path.return_value = "/nwb/path.nwb"
-        mock_get_nwb.return_value = mock_nwbf
+        mock_query.return_value.fetch_nwb.return_value = [
+            {"video_file": mock_video}
+        ]
 
-        with pytest.raises(FileNotFoundError, match="No ImageSeries found"):
+        with pytest.raises(FileNotFoundError, match="missing_video.mp4"):
             common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
 
 

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import pytest
 from pandas import DataFrame
 
@@ -58,14 +60,14 @@ def test_raw_position_fetch1_df(common, mini_pos, mini_pos_interval_dict):
     assert fetched.equals(raw), "RawPosition fetch1_dataframe failed"
 
 
-def test_raw_position_fetch_multi_df(common, mini_pos, mini_pos_interval_dict):
+def test_raw_position_fetch_multi_df(common):
     """Test RawPosition fetch1 dataframe"""
     shape = common.RawPosition().fetch1_dataframe().shape
     assert shape == (542, 8), "RawPosition.PosObj fetch1_dataframe failed"
 
 
-@pytest.fixture(scope="session")
-def pop_state_script(common):
+@pytest.fixture(scope="session", name="pop_state_script")
+def pop_state_script_fixture(common):
     """Populate state script"""
     keys = common.StateScriptFile.key_source
     common.StateScriptFile.populate()
@@ -81,15 +83,43 @@ def test_populate_state_script(common, pop_state_script):
     ), "StateScript populate unexpected effect"
 
 
-def test_videofile_update_entries(common, video_keys):
+def test_videofile_update_entries(common):
     """Test update entries"""
     key = common.VideoFile().fetch(as_dict=True)[0]
     common.VideoFile().update_entries(key)
 
 
-def test_videofile_getabspath(common, video_keys):
+def test_fetch_key_from_path_no_side_effect(common, tmp_path):
+    """fetch_key_from_path must not call update_entries by default."""
+    from unittest.mock import patch
+
+    fake = tmp_path / "no_such_video.mp4"
+    fake.touch()
+
+    with patch.object(common.VideoFile, "update_entries") as mock_update:
+        with pytest.raises(ValueError):
+            common.VideoFile().fetch_key_from_path(str(fake))
+        mock_update.assert_not_called()
+
+
+def test_fetch_key_from_path_update_on_miss(common, tmp_path):
+    """update_on_miss=True triggers update_entries then retries."""
+    from unittest.mock import patch
+
+    fake = tmp_path / "no_such_video.mp4"
+    fake.touch()
+
+    with patch.object(common.VideoFile, "update_entries") as mock_update:
+        with pytest.raises(ValueError):
+            common.VideoFile().fetch_key_from_path(
+                str(fake), update_on_miss=True
+            )
+        mock_update.assert_called_once()
+
+
+def test_videofile_getabspath(common):
     """Test get absolute path"""
-    key = video_keys[0]
+    key = common.VideoFile().fetch(as_dict=True)[0]
     path = common.VideoFile().get_abs_path(key)
     file_part = key["nwb_file_name"].split("2")[0] + "_0" + str(key["epoch"])
     assert file_part in path, "VideoFile get_abs_path failed"
@@ -100,7 +130,7 @@ def test_pos_interval_no_transaction(verbose_context, common, mini_restr):
     """Test no transaction"""
     before = common.PositionIntervalMap().fetch()
     with verbose_context:
-        common.PositionIntervalMap()._no_transaction_make(mini_restr)
+        common.PositionIntervalMap().make(mini_restr)
     after = common.PositionIntervalMap().fetch()
     expected_insertions = 4
     assert len(after) - len(before) == expected_insertions, (
@@ -112,7 +142,7 @@ def test_pos_interval_no_transaction(verbose_context, common, mini_restr):
     ), "PositionIntervalMap null insert failed"
 
 
-def test_get_pos_interval_name(pos_src, pos_interval_01):
+def test_get_pos_interval_name(pos_interval_01):
     """Test get pos interval name"""
     names = [f"pos {x} valid times" for x in range(1)]
     assert pos_interval_01 == names, "get_pos_interval_name failed"
@@ -128,3 +158,667 @@ def test_convert_epoch(common, mini_dict, pos_interval_01):
     assert (
         ret == pos_interval_01[0]
     ), "convert_epoch_interval_name_to_position_interval_name failed"
+
+
+def test_prepare_video_entry_with_external_file(common):
+    """Test _prepare_video_entry with external_file attribute."""
+    from pathlib import Path
+    from unittest.mock import MagicMock, Mock
+
+    # Create mock video object with external_file
+    mock_device = MagicMock()
+    mock_device.name = "camera_device 1"
+    mock_device.camera_name = "test_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "generic_video_name"
+    mock_video.external_file = ["file1.mp4", "file2.mp4", "file3.mp4"]
+
+    # Mock CameraDevice table to have the camera
+    key = {"test": "key"}
+
+    # Test with file_idx=None (should use index 0)
+    video_file = common.VideoFile()
+    with pytest.importorskip("unittest.mock").patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        mock_camera_device.__and__.return_value = True  # Camera exists
+
+        result = video_file._prepare_video_entry(key, mock_video)
+
+        expected_filename = Path("file1.mp4").name
+        assert expected_filename in result["path"]
+
+
+def test_prepare_video_entry_with_file_idx(common):
+    """Test _prepare_video_entry with specific file_idx."""
+    from pathlib import Path
+    from unittest.mock import MagicMock, Mock
+
+    # Create mock video object
+    mock_device = MagicMock()
+    mock_device.name = "camera_device 2"
+    mock_device.camera_name = "test_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "generic_video_name"
+    mock_video.external_file = ["file1.mp4", "file2.mp4", "file3.mp4"]
+
+    key = {"test": "key"}
+
+    # Test with file_idx=1 (should use second file)
+    video_file = common.VideoFile()
+    with pytest.importorskip("unittest.mock").patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        mock_camera_device.__and__.return_value = True
+
+        result = video_file._prepare_video_entry(key, mock_video, file_idx=1)
+
+        expected_filename = Path("file2.mp4").name
+        assert expected_filename in result["path"]
+
+
+def test_prepare_video_entry_with_empty_external_file(common):
+    """Test _prepare_video_entry with empty external_file list."""
+    from unittest.mock import MagicMock, Mock
+
+    # Create mock video object with empty external_file
+    mock_device = MagicMock()
+    mock_device.name = "camera_device 3"
+    mock_device.camera_name = "test_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "fallback_video_name"
+    mock_video.external_file = []  # Empty list
+
+    key = {"test": "key"}
+
+    video_file = common.VideoFile()
+    with pytest.importorskip("unittest.mock").patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        mock_camera_device.__and__.return_value = True
+
+        result = video_file._prepare_video_entry(key, mock_video)
+
+        # Should use video object name as fallback
+        assert "fallback_video_name" in result["path"]
+
+
+# Additional comprehensive tests for common_behav.py coverage improvement
+
+
+def test_prepare_video_entry_missing_camera(common):
+    """Test _prepare_video_entry with missing camera in CameraDevice table."""
+    from unittest.mock import MagicMock, Mock, patch
+
+    mock_device = MagicMock()
+    mock_device.name = "camera_device 4"
+    mock_device.camera_name = "nonexistent_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "test_video"
+    mock_video.external_file = ["test.mp4"]
+
+    key = {"test": "key"}
+
+    video_file = common.VideoFile()
+    with patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        # Mock camera not found
+        mock_camera_device.__and__.return_value = False
+
+        with pytest.raises(KeyError, match="No camera with camera_name"):
+            video_file._prepare_video_entry(key, mock_video)
+
+
+def test_prepare_video_entry_invalid_device_regex(common):
+    """Test _prepare_video_entry with invalid device name regex pattern."""
+    from unittest.mock import MagicMock, Mock, patch
+
+    mock_device = MagicMock()
+    mock_device.name = "invalid_camera_name"  # Doesn't match regex
+    mock_device.camera_name = "test_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "test_video"
+
+    key = {"test": "key"}
+
+    video_file = common.VideoFile()
+    with patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        mock_camera_device.__and__.return_value = True
+
+        with pytest.raises(ValueError, match="does not match expected pattern"):
+            video_file._prepare_video_entry(key, mock_video)
+
+
+def test_prepare_video_entry_file_idx_out_of_range(common):
+    """Test _prepare_video_entry with file_idx beyond external_file range."""
+    from unittest.mock import MagicMock, Mock, patch
+
+    mock_device = MagicMock()
+    mock_device.name = "camera_device 5"
+    mock_device.camera_name = "test_camera"
+
+    mock_video = Mock()
+    mock_video.device = mock_device
+    mock_video.object_id = "test_object_id"
+    mock_video.name = "fallback_name"
+    mock_video.external_file = ["file1.mp4"]  # Only 1 file
+
+    key = {"test": "key"}
+
+    video_file = common.VideoFile()
+    with patch.object(
+        common.common_behav, "CameraDevice"
+    ) as mock_camera_device:
+        mock_camera_device.__and__.return_value = True
+
+        # Request file_idx=2 when only 1 file exists
+        result = video_file._prepare_video_entry(key, mock_video, file_idx=2)
+
+        # Should fallback to video object name
+        assert "fallback_name" in result["path"]
+
+
+def test_validate_video_timestamps_single_file(common):
+    """Test _validate_video_timestamps for single-file ImageSeries."""
+    from unittest.mock import Mock, patch
+
+    import numpy as np
+
+    from spyglass.common.common_interval import Interval
+
+    # Create mock video object
+    mock_video = Mock()
+    mock_video.timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    mock_video.starting_frame = None  # Single file
+
+    # Mock valid times that overlap well (>90%)
+    valid_times = Mock(spec=Interval)
+    valid_times.contains.return_value = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    valid_times.times = [[0.5, 5.5]]  # Covers whole video
+
+    video_file = common.VideoFile()
+
+    with patch.object(video_file, "_prepare_video_entry") as mock_prepare:
+        mock_prepare.return_value = {"test": "entry"}
+
+        entries, failure, overlap_pct = video_file._validate_video_timestamps(
+            mock_video, valid_times, {"key": "value"}
+        )
+
+        assert len(entries) == 1
+        assert failure is None
+        assert overlap_pct == 1.0
+        mock_prepare.assert_called_once()
+
+
+def test_validate_video_timestamps_single_file_poor_overlap(common):
+    """Test _validate_video_timestamps with poor timestamp overlap."""
+    from unittest.mock import Mock
+
+    import numpy as np
+
+    mock_video = Mock()
+    mock_video.timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    mock_video.starting_frame = None
+
+    # Mock valid times with poor overlap
+    valid_times = Mock()
+    valid_times.contains.return_value = np.array([1.0])  # Only 1/5 = 20%
+    valid_times.times = [[6.0, 7.0]]  # Doesn't overlap
+
+    video_file = common.VideoFile()
+
+    entries, failure, overlap_pct = video_file._validate_video_timestamps(
+        mock_video, valid_times, {"key": "value"}
+    )
+
+    assert len(entries) == 0
+    assert "Only 20.0%" in failure
+    assert overlap_pct == pytest.approx(0.2)
+
+
+def test_validate_multifile_timestamps(common):
+    """Test _validate_multifile_timestamps validation logic."""
+    from unittest.mock import Mock, patch
+
+    import numpy as np
+
+    mock_video = Mock()
+    mock_video.object_id = "test_id"
+
+    timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    starting_frame = np.array([0, 3])  # Two files: [0-3) and [3-6)
+
+    # Mock valid times
+    valid_times = Mock()
+    # File 1 (timestamps 1-3): good overlap, File 2 (timestamps 4-6): poor overlap
+    valid_times.contains.side_effect = [
+        np.array([1.0, 2.0, 3.0]),  # File 1: 3/3 timestamps = 100% > 90%
+        np.array([4.0]),  # File 2: 1/3 timestamps = 33% < 90%
+    ]
+
+    video_file = common.VideoFile()
+
+    with patch.object(video_file, "_prepare_video_entry") as mock_prepare:
+        mock_prepare.return_value = {"test": "entry"}
+
+        entries, max_overlap = video_file._validate_multifile_timestamps(
+            mock_video,
+            timestamps,
+            starting_frame,
+            valid_times,
+            {"key": "value"},
+        )
+
+        # Should only return entry for file 1; max overlap is 100% from file 1
+        assert len(entries) == 1
+        assert max_overlap == pytest.approx(1.0)
+        mock_prepare.assert_called_once_with(
+            {"key": "value"}, mock_video, file_idx=0
+        )
+
+
+def test_validate_multifile_timestamps_no_valid_segments(common):
+    """Test _validate_multifile_timestamps when no segments meet threshold."""
+    from unittest.mock import Mock
+
+    import numpy as np
+
+    mock_video = Mock()
+    timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    starting_frame = np.array([0, 3])
+
+    # Mock valid times with poor overlap for all segments
+    valid_times = Mock()
+    valid_times.contains.side_effect = [
+        np.array([1.0]),  # File 1: 1/3 = 33% < 90%
+        np.array([4.0]),  # File 2: 1/3 = 33% < 90%
+    ]
+
+    video_file = common.VideoFile()
+
+    entries, max_overlap = video_file._validate_multifile_timestamps(
+        mock_video, timestamps, starting_frame, valid_times, {"key": "value"}
+    )
+
+    assert len(entries) == 0
+    assert max_overlap == pytest.approx(1 / 3)
+
+
+def test_videofile_make_no_videos(common):
+    """Test VideoFile.make when no ImageSeries found in NWB file."""
+    from unittest.mock import Mock, patch
+
+    # Mock NWB file with no ImageSeries objects
+    mock_nwbf = Mock()
+    mock_nwbf.objects.values.return_value = []  # No objects
+
+    video_file = common.VideoFile()
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_path.return_value = "/fake/path.nwb"
+
+        # Should not raise, just return early with warning
+        video_file.make({"nwb_file_name": "test.nwb"})
+
+
+def test_videofile_make_camera_device_error(common):
+    """Test VideoFile.make with camera device KeyError during processing."""
+    from unittest.mock import Mock, patch
+
+    import pynwb
+
+    # Mock NWB file with ImageSeries
+    mock_video = Mock(spec=pynwb.image.ImageSeries)
+    mock_video.name = "test_video"
+    mock_video.device.camera_name = "missing_camera"
+
+    mock_nwbf = Mock()
+    mock_nwbf.objects.values.return_value = [mock_video]
+
+    # Mock TaskEpoch and IntervalList
+    mock_interval = Mock()
+
+    video_file = common.VideoFile()
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
+        patch.object(common.TaskEpoch, "__and__") as mock_task_epoch,
+        patch.object(common.IntervalList, "__and__") as mock_interval_list,
+        patch.object(video_file, "_validate_video_timestamps") as mock_validate,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_path.return_value = "/fake/path.nwb"
+        mock_task_epoch.return_value.fetch1.return_value = "epoch01"
+        mock_interval_list.return_value.fetch_interval.return_value = (
+            mock_interval
+        )
+
+        # Simulate KeyError from _validate_video_timestamps
+        mock_validate.side_effect = KeyError("Camera not found")
+
+        # Should handle error gracefully
+        video_file.make({"nwb_file_name": "test.nwb"})
+
+
+def test_videofile_make_unexpected_error(common):
+    """Test VideoFile.make with unexpected error during processing."""
+    from unittest.mock import Mock, patch
+
+    import pynwb
+
+    mock_video = Mock(spec=pynwb.image.ImageSeries)
+    mock_video.name = "test_video"
+
+    mock_nwbf = Mock()
+    mock_nwbf.objects.values.return_value = [mock_video]
+
+    mock_interval = Mock()
+
+    video_file = common.VideoFile()
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_path,
+        patch.object(common.TaskEpoch, "__and__") as mock_task_epoch,
+        patch.object(common.IntervalList, "__and__") as mock_interval_list,
+        patch.object(video_file, "_validate_video_timestamps") as mock_validate,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_path.return_value = "/fake/path.nwb"
+        mock_task_epoch.return_value.fetch1.return_value = "epoch01"
+        mock_interval_list.return_value.fetch_interval.return_value = (
+            mock_interval
+        )
+
+        # Simulate unexpected error
+        mock_validate.side_effect = RuntimeError("Unexpected error")
+
+        # Should handle error gracefully
+        video_file.make({"nwb_file_name": "test.nwb"})
+
+
+def test_videofile_report_partial_import(common, caplog):
+    """Test VideoFile._report_partial_import logging functionality."""
+    from collections import defaultdict
+
+    failed_videos = defaultdict(list)
+    failed_videos["timestamp_mismatch"].append(
+        {"name": "video1", "reason": "Poor overlap", "overlap_percent": 20.0}
+    )
+    failed_videos["missing_camera"].append(
+        {"name": "video2", "camera": "cam1", "error": "Not found"}
+    )
+    failed_videos["other"].append(
+        {"name": "video3", "error": "RuntimeError: Something broke"}
+    )
+
+    common.VideoFile._report_partial_import("test.nwb", failed_videos, 5, 2)
+
+    # Check that logging contains expected information for diagnostics
+    assert "VideoFile Partial Import" in caplog.text
+    assert "Imported 2/5 ImageSeries" in caplog.text
+    assert "Timestamp mismatches" in caplog.text
+    assert "Missing camera devices" in caplog.text
+    assert "Other errors" in caplog.text
+
+
+def test_videofile_get_abs_path_with_stored_path(common):
+    """Test VideoFile.get_abs_path when path is already stored in database."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    # Mock stored path that exists
+    stored_path = "/stored/video/path.mp4"
+    video_info = {"path": stored_path}
+
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch.object(common.VideoFile, "__and__") as mock_query,
+    ):
+
+        mock_query.return_value.fetch1.return_value = video_info
+
+        result = common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
+
+        assert result == stored_path
+
+
+def test_videofile_get_abs_path_fallback_external_file(common):
+    """Test VideoFile.get_abs_path fallback to external_file when object name fails."""
+    from pathlib import Path
+    from unittest.mock import MagicMock, Mock, patch
+
+    import pynwb
+
+    # Mock scenario where stored path doesn't exist, object name doesn't exist,
+    # but external_file path exists
+    video_info = {"path": None, "video_file_object_id": "obj_123"}
+
+    # Mock ImageSeries with external_file
+    mock_video = Mock(spec=pynwb.image.ImageSeries)
+    mock_video.name = "nonexistent_video.mp4"
+    mock_video.external_file = ["/real/external/path.mp4"]
+
+    mock_nwbf = Mock()
+    mock_nwbf.objects = MagicMock()
+    mock_nwbf.objects.__getitem__.return_value = mock_video
+
+    with (
+        patch.object(common.VideoFile, "__and__") as mock_query,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(Path, "exists") as mock_exists,
+    ):
+
+        mock_query.return_value.fetch1.return_value = video_info
+        mock_get_abs_path.return_value = "/nwb/path.nwb"
+        mock_get_nwb.return_value = mock_nwbf
+
+        # Object-name path misses, then absolute external path resolves.
+        mock_exists.side_effect = [False, True]
+
+        result = common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
+
+        assert result == "/real/external/path.mp4"
+
+
+def test_videofile_get_abs_path_non_image_series_fallback(common):
+    """Test VideoFile.get_abs_path when object_id isn't ImageSeries."""
+    from pathlib import Path
+    from unittest.mock import MagicMock, Mock, patch
+
+    import pynwb
+
+    video_info = {"path": None, "video_file_object_id": "stale_obj_123"}
+
+    # Mock stale object that's not an ImageSeries
+    mock_stale_obj = Mock()  # Not an ImageSeries
+
+    # Mock real ImageSeries to fallback to
+    mock_video = Mock(spec=pynwb.image.ImageSeries)
+    mock_video.name = "real_video.mp4"
+    mock_video.external_file = ["real_video.mp4"]
+
+    mock_nwbf = Mock()
+    mock_nwbf.objects = MagicMock()
+    mock_nwbf.objects.__getitem__.return_value = mock_stale_obj
+    mock_nwbf.objects.values.return_value = [mock_stale_obj, mock_video]
+
+    with (
+        patch.object(common.VideoFile, "__and__") as mock_query,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch.object(Path, "exists") as mock_exists,
+    ):
+
+        mock_query.return_value.fetch1.return_value = video_info
+        mock_get_abs_path.return_value = "/nwb/path.nwb"
+        mock_get_nwb.return_value = mock_nwbf
+
+        # Fallback object-name path misses, then the external-file lookup under
+        # video_dir resolves.
+        mock_exists.side_effect = [False, True]
+
+        result = common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
+
+        # Should use the real ImageSeries object, not the stale reference
+        assert "real_video.mp4" in result
+
+
+def test_videofile_get_abs_path_no_image_series_error(common):
+    """Test VideoFile.get_abs_path when no ImageSeries found in NWB."""
+    from unittest.mock import MagicMock, Mock, patch
+
+    video_info = {"path": None, "video_file_object_id": "obj_123"}
+
+    # Mock non-ImageSeries object
+    mock_other_obj = Mock()
+
+    mock_nwbf = Mock()
+    mock_nwbf.objects = MagicMock()
+    mock_nwbf.objects.__getitem__.return_value = mock_other_obj
+    mock_nwbf.objects.values.return_value = [mock_other_obj]
+
+    with (
+        patch.object(common.VideoFile, "__and__") as mock_query,
+        patch.object(common.Nwbfile, "get_abs_path") as mock_get_abs_path,
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+    ):
+
+        mock_query.return_value.fetch1.return_value = video_info
+        mock_get_abs_path.return_value = "/nwb/path.nwb"
+        mock_get_nwb.return_value = mock_nwbf
+
+        with pytest.raises(FileNotFoundError, match="No ImageSeries found"):
+            common.VideoFile.get_abs_path({"nwb_file_name": "test.nwb"})
+
+
+def test_videofile_update_entries_with_null_values(common):
+    """Test VideoFile.update_entries with NULL camera_name or path values."""
+    from unittest.mock import Mock, patch
+
+    # Mock entries with NULL values
+    entries_with_nulls = [
+        {
+            "nwb_file_name": "test1.nwb",
+            "epoch": 1,
+            "camera_name": None,
+            "path": "/path",
+        },
+        {
+            "nwb_file_name": "test2.nwb",
+            "epoch": 2,
+            "camera_name": "cam1",
+            "path": None,
+        },
+    ]
+
+    row_relation = Mock()
+    row_relation.fetch_nwb.return_value = [
+        {"video_file": Mock(device=Mock(camera_name="new_camera"))}
+    ]
+
+    restrict_relation = Mock()
+    filtered_relation = Mock()
+    filtered_relation.fetch.return_value = entries_with_nulls
+    restrict_relation.__and__ = Mock(return_value=filtered_relation)
+
+    def and_side_effect(arg):
+        if arg is True:
+            return restrict_relation
+        if isinstance(arg, dict):
+            return row_relation
+        return Mock()
+
+    with (
+        patch.object(common.VideoFile, "__and__") as mock_query,
+        patch.object(common.VideoFile, "get_abs_path") as mock_get_abs_path,
+        patch.object(common.VideoFile, "update1") as mock_update1,
+    ):
+        mock_query.side_effect = and_side_effect
+        mock_get_abs_path.return_value = "/new/abs/path.mp4"
+
+        common.VideoFile.update_entries()
+
+        # Should call update for both entries
+        assert mock_update1.call_count == 2
+
+
+def test_position_source_invalid_interval_name(pos_src):
+    """Test PositionSource with invalid interval name formats."""
+    with pytest.raises(ValueError, match="Invalid interval name"):
+        pos_src.get_epoch_num("not_an_epoch_name")
+
+
+def test_position_source_insert_from_nwbfile(common):
+    """Test PositionSource.insert_from_nwbfile with no spatial series."""
+    from unittest.mock import Mock, patch
+
+    # Mock NWB file with no spatial series
+    mock_nwbf = Mock()
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch(
+            "spyglass.common.common_behav.get_all_spatial_series"
+        ) as mock_get_spatial,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_spatial.return_value = None  # No spatial series found
+
+        # Should not raise, just log info and return
+        common.PositionSource.insert_from_nwbfile("test.nwb")
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch(
+            "spyglass.common.common_behav.get_all_spatial_series"
+        ) as mock_get_spatial,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_spatial.return_value = None  # No spatial series found
+
+        # Should not raise, just log info and return
+        common.PositionSource.insert_from_nwbfile("test.nwb")
+
+    with (
+        patch("spyglass.common.common_behav.get_nwb_file") as mock_get_nwb,
+        patch(
+            "spyglass.common.common_behav.get_all_spatial_series"
+        ) as mock_get_spatial,
+    ):
+
+        mock_get_nwb.return_value = mock_nwbf
+        mock_get_spatial.return_value = None  # No spatial series found
+
+        # Should not raise, just log info and return
+        common.PositionSource.insert_from_nwbfile("test.nwb")

--- a/tests/common/test_session.py
+++ b/tests/common/test_session.py
@@ -1,0 +1,40 @@
+"""Tests for ``spyglass.common.common_session.Session``.
+
+These exercise the parts of ``common_session`` not reached by ordinary
+ingestion (the populate path only ever sees well-formed NWB metadata): the
+``Experimenter`` name-mapping branches and the ``with_date_str`` projection.
+"""
+
+from types import SimpleNamespace
+
+
+def test_experimenter_entries_from_multiple_names(common):
+    """``generate_entries_from_nwb_object`` maps each name via ``decompose_name``.
+
+    A synthetic NWB object (plain input stand-in, not an oracle) drives the
+    real method; the assertion pins the real ``decompose_name`` behaviour —
+    space- and comma-delimited names both normalise to ``"First Last"``.
+    """
+    exp = common.Session.Experimenter()
+    nwb_obj = SimpleNamespace(experimenter=["Alice Wonderland", "Builder, Bob"])
+    result = exp.generate_entries_from_nwb_object(nwb_obj)
+    entries = next(iter(result.values()))
+    assert [e["lab_member_name"] for e in entries] == [
+        "Alice Wonderland",
+        "Bob Builder",
+    ]
+
+
+def test_experimenter_entries_empty_when_no_metadata(common):
+    """Missing experimenter metadata takes the early-return branch."""
+    exp = common.Session.Experimenter()
+    nwb_obj = SimpleNamespace(experimenter=None)
+    assert exp.generate_entries_from_nwb_object(nwb_obj) == {}
+
+
+def test_session_with_date_str(common, mini_restr):
+    """``with_date_str`` projects ``session_date_str`` as YYYYMMDD of start."""
+    sess = common.Session() & mini_restr
+    start = sess.fetch1("session_start_time")
+    date_str = sess.with_date_str.fetch1("session_date_str")
+    assert date_str == start.strftime("%Y%m%d")

--- a/tests/setup/test_config_schema.py
+++ b/tests/setup/test_config_schema.py
@@ -54,7 +54,12 @@ class TestConfigSchema:
 
         # Check directory_schema has all prefixes
         dir_schema = schema["directory_schema"]
-        assert set(dir_schema.keys()) == {"spyglass", "kachery", "dlc", "moseq"}
+        assert set(dir_schema.keys()) == {
+            "spyglass",
+            "kachery",
+            "pose",
+            "moseq",
+        }
 
     def test_validate_schema_passes_for_valid_schema(self):
         """Test that validate_schema() accepts valid schema."""
@@ -75,7 +80,7 @@ class TestConfigSchema:
                     "directory_schema": {
                         "spyglass": {"raw": "raw"},
                         "kachery": {"cloud": ".kachery-cloud"},
-                        # Missing dlc and moseq
+                        # Missing pose and moseq
                     }
                 }
             )
@@ -104,14 +109,14 @@ class TestSchemaConsistency:
     def test_schema_has_all_required_prefixes(self):
         """Test that schema has all 4 required directory prefixes."""
         schema = load_directory_schema()
-        assert set(schema.keys()) == {"spyglass", "kachery", "dlc", "moseq"}
+        assert set(schema.keys()) == {"spyglass", "kachery", "pose", "moseq"}
 
     @pytest.mark.parametrize(
         "prefix,expected_count",
         [
             ("spyglass", 8),
             ("kachery", 3),
-            ("dlc", 3),
+            ("pose", 3),
             ("moseq", 2),
         ],
     )
@@ -137,7 +142,7 @@ class TestSchemaConsistency:
                 },
             ),
             ("kachery", {"cloud", "temp", "storage"}),
-            ("dlc", {"project", "video", "output"}),
+            ("pose", {"project", "video", "output"}),
             ("moseq", {"project", "video"}),
         ],
     )
@@ -207,10 +212,10 @@ class TestInstallerConfig:
                         "storage": str(dirs["kachery_storage"]),
                         "temp": str(dirs["kachery_temp"]),
                     },
-                    "dlc_dirs": {
-                        "project": str(dirs["dlc_project"]),
-                        "video": str(dirs["dlc_video"]),
-                        "output": str(dirs["dlc_output"]),
+                    "pose_dirs": {
+                        "project": str(dirs["pose_project"]),
+                        "video": str(dirs["pose_video"]),
+                        "output": str(dirs["pose_output"]),
                     },
                     "moseq_dirs": {
                         "project": str(dirs["moseq_project"]),
@@ -223,7 +228,7 @@ class TestInstallerConfig:
             custom = config["custom"]
             assert "spyglass_dirs" in custom
             assert "kachery_dirs" in custom
-            assert "dlc_dirs" in custom
+            assert "pose_dirs" in custom
             assert "moseq_dirs" in custom
 
     def test_installer_directory_paths_match_schema(self):
@@ -304,7 +309,7 @@ class TestBackwardsCompatibility:
                 "storage": "kachery_storage",
                 "temp": "tmp",
             },
-            "dlc": {
+            "pose": {
                 "project": "projects",
                 "video": "video",
                 "output": "output",
@@ -345,7 +350,7 @@ class TestBackwardsCompatibility:
                 "storage": "kachery_storage",
                 "temp": "tmp",
             },
-            "dlc": {
+            "pose": {
                 "project": "projects",
                 "video": "video",
                 "output": "output",
@@ -473,11 +478,11 @@ class TestConfigCompatibility:
                         "storage": str(dirs["kachery_storage"]),
                         "temp": str(dirs["kachery_temp"]),
                     },
-                    "dlc_dirs": {
+                    "pose_dirs": {
                         "base": str(base_dir / "deeplabcut"),
-                        "project": str(dirs["dlc_project"]),
-                        "video": str(dirs["dlc_video"]),
-                        "output": str(dirs["dlc_output"]),
+                        "project": str(dirs["pose_project"]),
+                        "video": str(dirs["pose_video"]),
+                        "output": str(dirs["pose_output"]),
                     },
                     "moseq_dirs": {
                         "base": str(base_dir / "moseq"),
@@ -607,11 +612,11 @@ class TestExampleConfigSync:
                         "storage": str(dirs["kachery_storage"]),
                         "temp": str(dirs["kachery_temp"]),
                     },
-                    "dlc_dirs": {
+                    "pose_dirs": {
                         "base": str(base_dir / "deeplabcut"),
-                        "project": str(dirs["dlc_project"]),
-                        "video": str(dirs["dlc_video"]),
-                        "output": str(dirs["dlc_output"]),
+                        "project": str(dirs["pose_project"]),
+                        "video": str(dirs["pose_video"]),
+                        "output": str(dirs["pose_output"]),
                     },
                     "moseq_dirs": {
                         "base": str(base_dir / "moseq"),
@@ -683,7 +688,7 @@ class TestExampleConfigSync:
         required_groups = [
             "spyglass_dirs",
             "kachery_dirs",
-            "dlc_dirs",
+            "pose_dirs",
             "moseq_dirs",
         ]
         for group in required_groups:

--- a/tests/setup/test_config_schema.py
+++ b/tests/setup/test_config_schema.py
@@ -49,8 +49,6 @@ class TestConfigSchema:
 
         # Check top-level structure
         assert isinstance(schema, dict)
-        assert "directory_schema" in schema
-        assert "tls" in schema
 
         # Check directory_schema has all prefixes
         dir_schema = schema["directory_schema"]
@@ -60,6 +58,11 @@ class TestConfigSchema:
             "pose",
             "moseq",
         }
+
+        # Check tls section defines the concrete localhost policy
+        tls = schema["tls"]
+        assert tls["auto_enable_for_remote"] is True
+        assert tls["localhost_addresses"] == ["localhost", "127.0.0.1", "::1"]
 
     def test_validate_schema_passes_for_valid_schema(self):
         """Test that validate_schema() accepts valid schema."""
@@ -183,53 +186,6 @@ class TestInstallerConfig:
             # Should return dict but not create dirs
             assert len(dirs) == 16
             assert not (base_dir / "raw").exists()
-
-    def test_installer_config_has_all_directory_groups(self):
-        """Test that installer creates config with all 4 directory groups."""
-        with TemporaryDirectory() as tmpdir:
-            base_dir = Path(tmpdir) / "spyglass_data"
-
-            # Simulate what create_database_config does
-            dirs = build_directory_structure(
-                base_dir, create=True, verbose=False
-            )
-
-            config = {
-                "custom": {
-                    "spyglass_dirs": {
-                        "base": str(base_dir),
-                        "raw": str(dirs["spyglass_raw"]),
-                        "analysis": str(dirs["spyglass_analysis"]),
-                        "recording": str(dirs["spyglass_recording"]),
-                        "sorting": str(dirs["spyglass_sorting"]),
-                        "waveforms": str(dirs["spyglass_waveforms"]),
-                        "temp": str(dirs["spyglass_temp"]),
-                        "video": str(dirs["spyglass_video"]),
-                        "export": str(dirs["spyglass_export"]),
-                    },
-                    "kachery_dirs": {
-                        "cloud": str(dirs["kachery_cloud"]),
-                        "storage": str(dirs["kachery_storage"]),
-                        "temp": str(dirs["kachery_temp"]),
-                    },
-                    "pose_dirs": {
-                        "project": str(dirs["pose_project"]),
-                        "video": str(dirs["pose_video"]),
-                        "output": str(dirs["pose_output"]),
-                    },
-                    "moseq_dirs": {
-                        "project": str(dirs["moseq_project"]),
-                        "video": str(dirs["moseq_video"]),
-                    },
-                }
-            }
-
-            # Verify all groups present
-            custom = config["custom"]
-            assert "spyglass_dirs" in custom
-            assert "kachery_dirs" in custom
-            assert "pose_dirs" in custom
-            assert "moseq_dirs" in custom
 
     def test_installer_directory_paths_match_schema(self):
         """Test that installer constructs paths according to schema."""
@@ -400,16 +356,18 @@ class TestSchemaVersioning:
     """Tests for schema versioning."""
 
     def test_schema_has_version(self):
-        """Test that schema file includes version."""
+        """Test that schema file declares the expected version."""
         schema = load_full_schema()
-        assert "_schema_version" in schema
         assert schema["_schema_version"] == "1.0.0"
 
     def test_version_history_present(self):
-        """Test that version history is documented."""
+        """Test that version history documents the 1.0.0 entry."""
         schema = load_full_schema()
-        assert "_version_history" in schema
-        assert "1.0.0" in schema["_version_history"]
+        assert set(schema["_version_history"]) == {"1.0.0"}
+        assert schema["_version_history"]["1.0.0"] == (
+            "Initial DRY architecture - JSON schema replaces "
+            "hard-coded directory structure"
+        )
 
 
 class TestConfigCompatibility:
@@ -684,32 +642,27 @@ class TestExampleConfigSync:
 
         custom = example_config["custom"]
 
-        # Check all 4 directory groups present
-        required_groups = [
+        # The *_dirs groups must be exactly the four schema prefixes
+        dir_groups = {k for k in custom if k.endswith("_dirs")}
+        assert dir_groups == {
             "spyglass_dirs",
             "kachery_dirs",
             "pose_dirs",
             "moseq_dirs",
-        ]
-        for group in required_groups:
-            assert (
-                group in custom
-            ), f"dj_local_conf_example.json missing '{group}' in custom section"
+        }, f"Unexpected directory groups in example config: {dir_groups}"
 
-    def test_example_config_is_valid_json(self):
-        """Test that dj_local_conf_example.json is valid JSON."""
-        example_path = (
-            Path(__file__).parent.parent.parent / "dj_local_conf_example.json"
-        )
-
-        assert (
-            example_path.exists()
-        ), "dj_local_conf_example.json not found in repo root"
-
-        # Should not raise JSONDecodeError
-        with open(example_path) as f:
-            config = json.load(f)
-
-        assert isinstance(
-            config, dict
-        ), "Example config should be a JSON object (dict)"
+        # Each group's keys must match the schema's keys for that prefix
+        schema = load_directory_schema()
+        for group, prefix in (
+            ("spyglass_dirs", "spyglass"),
+            ("kachery_dirs", "kachery"),
+            ("pose_dirs", "pose"),
+            ("moseq_dirs", "moseq"),
+        ):
+            schema_keys = set(schema[prefix].keys())
+            example_keys = set(custom[group].keys())
+            # Example may add a "base" key not present in the schema
+            assert schema_keys <= example_keys, (
+                f"{group} missing keys {schema_keys - example_keys} "
+                "present in directory_schema.json"
+            )

--- a/tests/setup/test_install.py
+++ b/tests/setup/test_install.py
@@ -54,28 +54,23 @@ from install import (
 class TestGetRequiredPythonVersion:
     """Tests for get_required_python_version()."""
 
-    def test_returns_tuple(self):
-        """Returns a tuple of two integers."""
-        version = get_required_python_version()
-        assert isinstance(version, tuple)
-        assert len(version) == 2
+    def test_matches_pyproject_lower_bound(self):
+        """Returns the ``>=`` lower bound parsed from pyproject.toml."""
+        import re
 
-    def test_version_is_reasonable(self):
-        """Returned version is within expected range (3.10-3.13)."""
-        major, minor = get_required_python_version()
-        assert major == 3
-        assert 10 <= minor <= 13
-
-    def test_reads_from_pyproject_toml(self):
-        """Reads version from pyproject.toml, not hardcoded."""
-        # Verify pyproject.toml exists and has requires-python
         pyproject_path = scripts_dir.parent / "pyproject.toml"
-        assert pyproject_path.exists(), "pyproject.toml not found"
+        requires = re.search(
+            r'requires-python\s*=\s*"([^"]+)"',
+            pyproject_path.read_text(),
+        ).group(1)
+        bound = re.search(r">=(\d+)\.(\d+)", requires)
+        expected = (int(bound.group(1)), int(bound.group(2)))
 
-        content = pyproject_path.read_text()
-        assert (
-            "requires-python" in content
-        ), "pyproject.toml should have requires-python"
+        assert get_required_python_version() == expected
+
+    def test_version_is_exactly_3_10(self):
+        """pyproject currently pins the lower bound at 3.10."""
+        assert get_required_python_version() == (3, 10)
 
 
 # =============================================================================
@@ -378,20 +373,19 @@ class TestCheckDiskSpace:
     """Tests for check_disk_space()."""
 
     def test_existing_path(self, tmp_path):
-        """Returns disk space for existing path."""
+        """Returned available GB matches shutil.disk_usage for the path."""
+        import shutil
+
         sufficient, available = check_disk_space(1, tmp_path)
-        # Should have at least 1 GB on any modern system
-        assert isinstance(sufficient, bool)
-        assert isinstance(available, int)
-        assert available >= 0
+        expected_available = int(shutil.disk_usage(tmp_path).free / 1024**3)
+        assert available == expected_available
+        assert sufficient is (expected_available >= 1)
 
     def test_nonexistent_path_checks_parent(self, tmp_path):
-        """Walks up tree to find existing parent for non-existent path."""
+        """Non-existent path yields the same result as its existing parent."""
         nonexistent = tmp_path / "does" / "not" / "exist"
-        sufficient, available = check_disk_space(1, nonexistent)
-        # Should still work by checking tmp_path
-        assert isinstance(sufficient, bool)
-        assert isinstance(available, int)
+        # Walks up to tmp_path, so the result must match checking it directly.
+        assert check_disk_space(1, nonexistent) == check_disk_space(1, tmp_path)
 
     def test_returns_false_when_insufficient(self, tmp_path):
         """Returns False when space is insufficient."""
@@ -627,7 +621,12 @@ class TestValidateDatabaseConfig:
             password="password",
         )
         assert valid is False
-        assert len(errors) >= 3  # At least host, port, user errors
+        # Empty host, out-of-range port, and empty user each add one error;
+        # the valid password adds none, so exactly three are collected.
+        assert len(errors) == 3
+        assert any("hostname" in e.lower() for e in errors)
+        assert any("port" in e.lower() for e in errors)
+        assert any("username" in e.lower() for e in errors)
 
 
 # =============================================================================
@@ -945,14 +944,16 @@ class TestBuildDirectoryStructure:
         assert not base_dir.exists()
 
     def test_creates_expected_prefixes(self, tmp_path):
-        """Creates directories for all four prefixes."""
+        """Each prefix contributes its exact number of directories."""
         base_dir = tmp_path / "spyglass_data"
         dirs = build_directory_structure(base_dir, create=True, verbose=False)
 
-        prefixes = {"spyglass", "kachery", "pose", "moseq"}
-        for prefix in prefixes:
-            matching = [k for k in dirs.keys() if k.startswith(f"{prefix}_")]
-            assert len(matching) > 0, f"No directories for prefix {prefix}"
+        # Counts follow directory_schema.json: spyglass has 8 subdirs,
+        # kachery 3, pose 3, moseq 2 (16 total).
+        expected_counts = {"spyglass": 8, "kachery": 3, "pose": 3, "moseq": 2}
+        for prefix, count in expected_counts.items():
+            matching = [k for k in dirs if k.startswith(f"{prefix}_")]
+            assert len(matching) == count, f"prefix {prefix}"
 
 
 # =============================================================================
@@ -1480,11 +1481,6 @@ class TestConfigOnlyErrorScenarios:
 class TestLoadDirectorySchema:
     """Tests for load_directory_schema()."""
 
-    def test_returns_dict(self):
-        """Returns a dictionary."""
-        schema = load_directory_schema()
-        assert isinstance(schema, dict)
-
     def test_has_all_prefixes(self):
         """Has all four required prefixes."""
         schema = load_directory_schema()
@@ -1597,6 +1593,13 @@ class TestCreateDatabaseConfig:
             "custom",
         }
         assert required_keys.issubset(set(config.keys()))
+        # Concrete values for the DataJoint general settings
+        assert config["filepath_checksum_size_limit"] == 1 * 1024**3
+        assert config["enable_python_native_blobs"] is True
+        assert config["database.reconnect"] is True
+        assert config["safemode"] is True
+        assert config["loglevel"] == "INFO"
+        assert config["fetch_format"] == "array"
 
     def test_config_has_stores_with_raw_and_analysis(
         self, tmp_path, monkeypatch
@@ -1620,15 +1623,14 @@ class TestCreateDatabaseConfig:
             config = json.load(f)
 
         stores = config["stores"]
-        assert "raw" in stores
-        assert "analysis" in stores
-
-        # Each store should have protocol, location, stage
+        # Schema maps spyglass.raw -> "raw", spyglass.analysis -> "analysis",
+        # so each store's location and stage are base_dir/<name>.
         for store_name in ["raw", "analysis"]:
             store = stores[store_name]
+            expected = str(base_dir / store_name)
             assert store["protocol"] == "file"
-            assert "location" in store
-            assert "stage" in store
+            assert store["location"] == expected
+            assert store["stage"] == expected
 
     def test_config_has_custom_spyglass_dirs(self, tmp_path, monkeypatch):
         """Config file has all spyglass directory paths in custom section."""
@@ -1794,28 +1796,6 @@ class TestCreateDatabaseConfig:
                 path.is_dir()
             ), f"spyglass_dirs.{key} ({path}) is not a directory"
 
-    def test_config_file_is_valid_json(self, tmp_path, monkeypatch):
-        """Config file is valid JSON that can be parsed."""
-        import json
-
-        config_file = tmp_path / ".datajoint_config.json"
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-        base_dir = tmp_path / "spyglass_data"
-        create_database_config(
-            host="localhost",
-            port=3306,
-            user="root",
-            password="pass",
-            base_dir=base_dir,
-        )
-
-        # This should not raise
-        with config_file.open() as f:
-            config = json.load(f)
-
-        assert isinstance(config, dict)
-
     def test_tls_auto_enabled_for_remote_host(self, tmp_path, monkeypatch):
         """TLS is automatically enabled for non-localhost hosts."""
         import json
@@ -1958,10 +1938,29 @@ class TestFrankLabConfig:
             config = json.load(f)
 
         custom = config["custom"]
-        assert "spyglass_dirs" in custom
-        assert "kachery_dirs" in custom
-        assert "pose_dirs" in custom
-        assert "moseq_dirs" in custom
+        assert set(custom["spyglass_dirs"].keys()) == {
+            "base",
+            "raw",
+            "analysis",
+            "recording",
+            "sorting",
+            "waveforms",
+            "temp",
+            "video",
+            "export",
+        }
+        assert set(custom["kachery_dirs"].keys()) == {
+            "cloud",
+            "storage",
+            "temp",
+        }
+        assert set(custom["pose_dirs"].keys()) == {
+            "base",
+            "project",
+            "video",
+            "output",
+        }
+        assert set(custom["moseq_dirs"].keys()) == {"base", "project", "video"}
 
     def test_franklab_config_directories_match_schema(
         self, tmp_path, monkeypatch
@@ -2152,12 +2151,6 @@ class TestConfigOnlyMode:
 @pytest.mark.integration
 class TestSetupFranklabScript:
     """Integration tests for setup_franklab.sh script."""
-
-    def test_setup_franklab_script_exists(self):
-        """setup_franklab.sh script exists."""
-        franklab_script = scripts_dir / "setup_franklab.sh"
-        assert franklab_script.exists()
-        assert franklab_script.is_file()
 
     def test_setup_franklab_help_runs(self):
         """setup_franklab.sh --help runs without error."""

--- a/tests/setup/test_install.py
+++ b/tests/setup/test_install.py
@@ -949,7 +949,7 @@ class TestBuildDirectoryStructure:
         base_dir = tmp_path / "spyglass_data"
         dirs = build_directory_structure(base_dir, create=True, verbose=False)
 
-        prefixes = {"spyglass", "kachery", "dlc", "moseq"}
+        prefixes = {"spyglass", "kachery", "pose", "moseq"}
         for prefix in prefixes:
             matching = [k for k in dirs.keys() if k.startswith(f"{prefix}_")]
             assert len(matching) > 0, f"No directories for prefix {prefix}"
@@ -982,7 +982,7 @@ class TestValidateSchema:
                     "storage": "kachery_storage",
                     "temp": "tmp",
                 },
-                "dlc": {
+                "pose": {
                     "project": "projects",
                     "video": "video",
                     "output": "output",
@@ -1004,7 +1004,7 @@ class TestValidateSchema:
             "directory_schema": {
                 "spyglass": {"raw": "raw"},
                 "kachery": {"cloud": ".kachery-cloud"},
-                # Missing dlc and moseq
+                # Missing pose and moseq
             }
         }
         with pytest.raises(ValueError, match="Missing prefixes"):
@@ -1488,7 +1488,7 @@ class TestLoadDirectorySchema:
     def test_has_all_prefixes(self):
         """Has all four required prefixes."""
         schema = load_directory_schema()
-        assert set(schema.keys()) == {"spyglass", "kachery", "dlc", "moseq"}
+        assert set(schema.keys()) == {"spyglass", "kachery", "pose", "moseq"}
 
     def test_spyglass_has_expected_keys(self):
         """spyglass prefix has expected directory keys."""
@@ -1511,11 +1511,11 @@ class TestLoadDirectorySchema:
         expected = {"cloud", "storage", "temp"}
         assert set(schema["kachery"].keys()) == expected
 
-    def test_dlc_has_expected_keys(self):
-        """dlc prefix has expected directory keys."""
+    def test_pose_has_expected_keys(self):
+        """pose prefix has expected directory keys."""
         schema = load_directory_schema()
         expected = {"project", "video", "output"}
-        assert set(schema["dlc"].keys()) == expected
+        assert set(schema["pose"].keys()) == expected
 
     def test_moseq_has_expected_keys(self):
         """moseq prefix has expected directory keys."""
@@ -1689,7 +1689,7 @@ class TestCreateDatabaseConfig:
         expected_keys = {"cloud", "storage", "temp"}
         assert set(kachery_dirs.keys()) == expected_keys
 
-    def test_config_has_dlc_dirs(self, tmp_path, monkeypatch):
+    def test_config_has_pose_dirs(self, tmp_path, monkeypatch):
         """Config file has DeepLabCut directory paths."""
         import json
 
@@ -1708,9 +1708,9 @@ class TestCreateDatabaseConfig:
         with config_file.open() as f:
             config = json.load(f)
 
-        dlc_dirs = config["custom"]["dlc_dirs"]
+        pose_dirs = config["custom"]["pose_dirs"]
         expected_keys = {"base", "project", "video", "output"}
-        assert set(dlc_dirs.keys()) == expected_keys
+        assert set(pose_dirs.keys()) == expected_keys
 
     def test_config_has_moseq_dirs(self, tmp_path, monkeypatch):
         """Config file has MoSeq directory paths."""
@@ -1960,7 +1960,7 @@ class TestFrankLabConfig:
         custom = config["custom"]
         assert "spyglass_dirs" in custom
         assert "kachery_dirs" in custom
-        assert "dlc_dirs" in custom
+        assert "pose_dirs" in custom
         assert "moseq_dirs" in custom
 
     def test_franklab_config_directories_match_schema(
@@ -2280,11 +2280,11 @@ class TestConfigCompatibility:
                     "storage": str(dirs["kachery_storage"]),
                     "temp": str(dirs["kachery_temp"]),
                 },
-                "dlc_dirs": {
+                "pose_dirs": {
                     "base": str(base_dir / "deeplabcut"),
-                    "project": str(dirs["dlc_project"]),
-                    "video": str(dirs["dlc_video"]),
-                    "output": str(dirs["dlc_output"]),
+                    "project": str(dirs["pose_project"]),
+                    "video": str(dirs["pose_video"]),
+                    "output": str(dirs["pose_output"]),
                 },
                 "moseq_dirs": {
                     "base": str(base_dir / "moseq"),

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,4 +1,5 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +13,13 @@ def excepthook():
     return excepthook
 
 
+@pytest.fixture(scope="module")
+def spyglass_logger():
+    from spyglass.utils.logging import SpyglassLogger
+
+    return SpyglassLogger("test_spyglass")
+
+
 @pytest.mark.skipif(not VERBOSE, reason="No logging to test when quiet-spy.")
 def test_existing_excepthook(caplog, excepthook):
     try:
@@ -20,3 +28,248 @@ def test_existing_excepthook(caplog, excepthook):
         excepthook(*sys.exc_info())
 
     assert "Uncaught exception" in caplog.text, "No warning issued."
+
+
+def test_get_test_mode_normal(spyglass_logger):
+    result = spyglass_logger._get_test_mode()
+    assert isinstance(result, bool)
+
+
+def test_get_test_mode_import_error(spyglass_logger):
+    with patch.dict("sys.modules", {"spyglass.settings": None}):
+        result = spyglass_logger._get_test_mode()
+    assert result is False
+
+
+def test_info_msg_uses_debug_in_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=True):
+        with patch.object(spyglass_logger, "debug") as mock_debug:
+            spyglass_logger.info_msg("hello")
+    mock_debug.assert_called_once_with("hello")
+
+
+def test_info_msg_uses_info_outside_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=False):
+        with patch.object(spyglass_logger, "info") as mock_info:
+            spyglass_logger.info_msg("hello")
+    mock_info.assert_called_once_with("hello")
+
+
+def test_warn_msg_uses_debug_in_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=True):
+        with patch.object(spyglass_logger, "debug") as mock_debug:
+            spyglass_logger.warn_msg("hello")
+    mock_debug.assert_called_once_with("hello")
+
+
+def test_warn_msg_uses_warning_outside_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=False):
+        with patch.object(spyglass_logger, "warning") as mock_warning:
+            spyglass_logger.warn_msg("hello")
+    mock_warning.assert_called_once_with("hello")
+
+
+def test_error_msg_uses_debug_in_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=True):
+        with patch.object(spyglass_logger, "debug") as mock_debug:
+            spyglass_logger.error_msg("hello")
+    mock_debug.assert_called_once_with("hello")
+
+
+def test_error_msg_uses_error_outside_test_mode(spyglass_logger):
+    with patch.object(spyglass_logger, "_get_test_mode", return_value=False):
+        with patch.object(spyglass_logger, "error") as mock_error:
+            spyglass_logger.error_msg("hello")
+    mock_error.assert_called_once_with("hello")
+
+
+def test_module_info_msg_delegates():
+    from spyglass.utils.logging import info_msg, logger
+
+    with patch.object(logger, "info_msg") as mock:
+        info_msg("test")
+    mock.assert_called_once_with("test")
+
+
+def test_module_warn_msg_delegates():
+    from spyglass.utils.logging import logger, warn_msg
+
+    with patch.object(logger, "warn_msg") as mock:
+        warn_msg("test")
+    mock.assert_called_once_with("test")
+
+
+def test_module_error_msg_delegates():
+    from spyglass.utils.logging import error_msg, logger
+
+    with patch.object(logger, "error_msg") as mock:
+        error_msg("test")
+    mock.assert_called_once_with("test")
+
+
+def test_excepthook_keyboard_interrupt_uses_system_handler(excepthook):
+    """Test that KeyboardInterrupt uses the system exception handler."""
+    exc_instance = KeyboardInterrupt("test")
+    with patch.object(sys, "__excepthook__") as mock_sys_excepthook:
+        excepthook(KeyboardInterrupt, exc_instance, None)
+    mock_sys_excepthook.assert_called_once_with(
+        KeyboardInterrupt, exc_instance, None
+    )
+
+
+def test_spyglass_logger_basic_functionality():
+    """Test SpyglassLogger basic functionality."""
+
+    from spyglass.utils.logging import SpyglassLogger
+
+    # Test logger creation
+    logger = SpyglassLogger("test_logger")
+    assert logger.name == "test_logger"
+
+    # Test required methods exist
+    assert hasattr(logger, "info_msg")
+    assert hasattr(logger, "warn_msg")
+    assert hasattr(logger, "error_msg")
+    assert hasattr(logger, "_get_test_mode")
+
+
+def test_spyglass_logger_test_mode_detection():
+    """Test test mode detection logic."""
+    from unittest.mock import patch
+
+    from spyglass.utils.logging import SpyglassLogger
+
+    logger = SpyglassLogger("test")
+
+    # Test with mock settings
+    with (
+        patch("spyglass.utils.logging.sg_config", {})
+        if "sg_config" in dir()
+        else patch.dict("sys.modules", {})
+    ):
+        # Default should be False when no config
+        test_mode = logger._get_test_mode()
+        assert isinstance(test_mode, bool)
+
+
+def test_spyglass_logger_message_methods():
+    """Test SpyglassLogger message methods."""
+    from unittest.mock import patch
+
+    from spyglass.utils.logging import SpyglassLogger
+
+    logger = SpyglassLogger("test")
+
+    # Test message methods work without crashing
+    try:
+        with patch.object(logger, "debug") as mock_debug:
+            with patch.object(logger, "_get_test_mode", return_value=True):
+                logger.info_msg("test info")
+                # In test mode, should use debug
+                mock_debug.assert_called_once_with("test info")
+    except Exception:
+        # Some configurations might not support this
+        pass
+
+
+def test_spyglass_logger_module_functions():
+    """Test module level logging functions."""
+    from spyglass.utils.logging import error_msg, info_msg, warn_msg
+
+    # Test functions exist and are callable
+    assert callable(info_msg)
+    assert callable(warn_msg)
+    assert callable(error_msg)
+
+    # Test they accept string arguments
+    try:
+        info_msg("test")
+        warn_msg("test")
+        error_msg("test")
+    except Exception:
+        # Should not crash with basic string input
+        pass
+
+
+def test_spyglass_logger_configuration():
+    """Test SpyglassLogger configuration handling."""
+    from spyglass.utils.logging import SpyglassLogger
+
+    # Test logger with different names
+    logger1 = SpyglassLogger("logger1")
+    logger2 = SpyglassLogger("logger2")
+
+    assert logger1.name != logger2.name
+    assert logger1.name == "logger1"
+    assert logger2.name == "logger2"
+
+
+def test_spyglass_logger_edge_cases():
+    """Test SpyglassLogger edge cases."""
+    from spyglass.utils.logging import SpyglassLogger
+
+    # Test with empty name
+    logger_empty = SpyglassLogger("")
+    assert logger_empty.name == ""
+
+    # Test with various message types
+    SpyglassLogger("test")
+
+    # Should handle different message types
+    test_messages = ["string", 123, None, [1, 2, 3]]
+
+    for msg in test_messages:
+        try:
+            # Convert to string for logging
+            str_msg = str(msg)
+            assert isinstance(str_msg, str)
+        except Exception:
+            # Some edge cases might not convert properly
+            pass
+
+
+def test_excepthook_basic_functionality():
+    """Test excepthook basic functionality."""
+    import sys
+
+    from spyglass.utils.logging import excepthook
+
+    # Test that excepthook is callable
+    assert callable(excepthook)
+
+    # Test with keyboard interrupt (should use system handler)
+    with patch.object(sys, "__excepthook__") as mock_sys_hook:
+        try:
+            excepthook(KeyboardInterrupt, KeyboardInterrupt("test"), None)
+            # Should delegate to system handler for KeyboardInterrupt
+            mock_sys_hook.assert_called_once()
+        except Exception:
+            # Excepthook might have different behavior in test environment
+            pass
+
+
+@pytest.mark.parametrize(
+    "msg_type,logger_method",
+    [
+        ("info", "info"),
+        ("warning", "warning"),
+        ("error", "error"),
+        ("debug", "debug"),
+    ],
+)
+def test_logger_methods_coverage(msg_type, logger_method):
+    from spyglass.utils import logger
+
+    assert hasattr(logger, logger_method)
+    with patch.object(logger, logger_method) as mock_method:
+        getattr(logger, logger_method)(f"Test {msg_type} message")
+        mock_method.assert_called_once_with(f"Test {msg_type} message")
+
+
+def test_logging_configuration():
+    from spyglass.utils.logging import logger
+
+    assert logger is not None
+    assert hasattr(logger, "info")
+    assert hasattr(logger, "warning")
+    assert hasattr(logger, "error")

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -161,15 +161,11 @@ def test_spyglass_logger_message_methods():
     logger = SpyglassLogger("test")
 
     # Test message methods work without crashing
-    try:
-        with patch.object(logger, "debug") as mock_debug:
-            with patch.object(logger, "_get_test_mode", return_value=True):
-                logger.info_msg("test info")
-                # In test mode, should use debug
-                mock_debug.assert_called_once_with("test info")
-    except Exception:
-        # Some configurations might not support this
-        pass
+    with patch.object(logger, "debug") as mock_debug:
+        with patch.object(logger, "_get_test_mode", return_value=True):
+            logger.info_msg("test info")
+            # In test mode, should use debug
+            mock_debug.assert_called_once_with("test info")
 
 
 def test_spyglass_logger_module_functions():
@@ -182,13 +178,9 @@ def test_spyglass_logger_module_functions():
     assert callable(error_msg)
 
     # Test they accept string arguments
-    try:
-        info_msg("test")
-        warn_msg("test")
-        error_msg("test")
-    except Exception:
-        # Should not crash with basic string input
-        pass
+    info_msg("test")
+    warn_msg("test")
+    error_msg("test")
 
 
 def test_spyglass_logger_configuration():
@@ -239,13 +231,9 @@ def test_excepthook_basic_functionality():
 
     # Test with keyboard interrupt (should use system handler)
     with patch.object(sys, "__excepthook__") as mock_sys_hook:
-        try:
-            excepthook(KeyboardInterrupt, KeyboardInterrupt("test"), None)
-            # Should delegate to system handler for KeyboardInterrupt
-            mock_sys_hook.assert_called_once()
-        except Exception:
-            # Excepthook might have different behavior in test environment
-            pass
+        excepthook(KeyboardInterrupt, KeyboardInterrupt("test"), None)
+        # Should delegate to system handler for KeyboardInterrupt
+        mock_sys_hook.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from unittest.mock import patch
 
@@ -31,8 +32,11 @@ def test_existing_excepthook(caplog, excepthook):
 
 
 def test_get_test_mode_normal(spyglass_logger):
+    from spyglass.settings import config as sg_config
+
     result = spyglass_logger._get_test_mode()
     assert isinstance(result, bool)
+    assert result == sg_config.get("test_mode", False)
 
 
 def test_get_test_mode_import_error(spyglass_logger):
@@ -117,77 +121,10 @@ def test_excepthook_keyboard_interrupt_uses_system_handler(excepthook):
     )
 
 
-def test_spyglass_logger_basic_functionality():
-    """Test SpyglassLogger basic functionality."""
-
-    from spyglass.utils.logging import SpyglassLogger
-
-    # Test logger creation
-    logger = SpyglassLogger("test_logger")
-    assert logger.name == "test_logger"
-
-    # Test required methods exist
-    assert hasattr(logger, "info_msg")
-    assert hasattr(logger, "warn_msg")
-    assert hasattr(logger, "error_msg")
-    assert hasattr(logger, "_get_test_mode")
-
-
-def test_spyglass_logger_test_mode_detection():
-    """Test test mode detection logic."""
-    from unittest.mock import patch
-
-    from spyglass.utils.logging import SpyglassLogger
-
-    logger = SpyglassLogger("test")
-
-    # Test with mock settings
-    with (
-        patch("spyglass.utils.logging.sg_config", {})
-        if "sg_config" in dir()
-        else patch.dict("sys.modules", {})
-    ):
-        # Default should be False when no config
-        test_mode = logger._get_test_mode()
-        assert isinstance(test_mode, bool)
-
-
-def test_spyglass_logger_message_methods():
-    """Test SpyglassLogger message methods."""
-    from unittest.mock import patch
-
-    from spyglass.utils.logging import SpyglassLogger
-
-    logger = SpyglassLogger("test")
-
-    # Test message methods work without crashing
-    with patch.object(logger, "debug") as mock_debug:
-        with patch.object(logger, "_get_test_mode", return_value=True):
-            logger.info_msg("test info")
-            # In test mode, should use debug
-            mock_debug.assert_called_once_with("test info")
-
-
-def test_spyglass_logger_module_functions():
-    """Test module level logging functions."""
-    from spyglass.utils.logging import error_msg, info_msg, warn_msg
-
-    # Test functions exist and are callable
-    assert callable(info_msg)
-    assert callable(warn_msg)
-    assert callable(error_msg)
-
-    # Test they accept string arguments
-    info_msg("test")
-    warn_msg("test")
-    error_msg("test")
-
-
 def test_spyglass_logger_configuration():
-    """Test SpyglassLogger configuration handling."""
+    """Distinct names produce distinct SpyglassLogger instances."""
     from spyglass.utils.logging import SpyglassLogger
 
-    # Test logger with different names
     logger1 = SpyglassLogger("logger1")
     logger2 = SpyglassLogger("logger2")
 
@@ -197,67 +134,19 @@ def test_spyglass_logger_configuration():
 
 
 def test_spyglass_logger_edge_cases():
-    """Test SpyglassLogger edge cases."""
+    """SpyglassLogger accepts an empty name."""
     from spyglass.utils.logging import SpyglassLogger
 
-    # Test with empty name
     logger_empty = SpyglassLogger("")
     assert logger_empty.name == ""
-
-    # Test with various message types
-    SpyglassLogger("test")
-
-    # Should handle different message types
-    test_messages = ["string", 123, None, [1, 2, 3]]
-
-    for msg in test_messages:
-        try:
-            # Convert to string for logging
-            str_msg = str(msg)
-            assert isinstance(str_msg, str)
-        except Exception:
-            # Some edge cases might not convert properly
-            pass
-
-
-def test_excepthook_basic_functionality():
-    """Test excepthook basic functionality."""
-    import sys
-
-    from spyglass.utils.logging import excepthook
-
-    # Test that excepthook is callable
-    assert callable(excepthook)
-
-    # Test with keyboard interrupt (should use system handler)
-    with patch.object(sys, "__excepthook__") as mock_sys_hook:
-        excepthook(KeyboardInterrupt, KeyboardInterrupt("test"), None)
-        # Should delegate to system handler for KeyboardInterrupt
-        mock_sys_hook.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    "msg_type,logger_method",
-    [
-        ("info", "info"),
-        ("warning", "warning"),
-        ("error", "error"),
-        ("debug", "debug"),
-    ],
-)
-def test_logger_methods_coverage(msg_type, logger_method):
-    from spyglass.utils import logger
-
-    assert hasattr(logger, logger_method)
-    with patch.object(logger, logger_method) as mock_method:
-        getattr(logger, logger_method)(f"Test {msg_type} message")
-        mock_method.assert_called_once_with(f"Test {msg_type} message")
+    assert isinstance(logger_empty, SpyglassLogger)
 
 
 def test_logging_configuration():
-    from spyglass.utils.logging import logger
+    """The module-level logger is a configured SpyglassLogger."""
+    from spyglass.utils.logging import SpyglassLogger, logger
 
-    assert logger is not None
-    assert hasattr(logger, "info")
-    assert hasattr(logger, "warning")
-    assert hasattr(logger, "error")
+    assert isinstance(logger, SpyglassLogger)
+    assert logger.name == "spyglass"
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], logging.StreamHandler)


### PR DESCRIPTION
## PR 2 of 7 — Common infrastructure

`pv2-pr1 ← pv2-pr2` · **13 files**

Prerequisites the V2 pipeline builds on. Staged verbatim from `pv2`.

### What's here
- `spyglass.utils.logging` (new) + tests.
- **`VideoFile` path support** — new `path` column + helpers
  (`get_abs_paths`, `fetch_key_from_path`, `_narrow_key_lookup`, `update_entries`).
- **Config rename** `dlc_dirs → pose_dirs` (`settings.py`, `directory_schema.json`,
  `dj_local_conf_example.json`, installer, config-schema tests).
- `Session.with_date_str`.

### ⚠️ Breaking migrations (apply manually — not auto-run)
1. `VideoFile` gains a `path` column → an `alter()` on an existing common table.
2. `dj_local_conf` key `dlc_dirs` → `pose_dirs` → users must update local config
   (`settings.py` keeps `dlc_project_dir` as a deprecated alias).
