### PR TITLE
PR6: V2 3D / multicam / anipose

### DIFF
--- a/src/spyglass/position/v2/utils/triangulation.py
+++ b/src/spyglass/position/v2/utils/triangulation.py
@@ -1,0 +1,376 @@
+"""3-D triangulation utilities for multi-camera pose estimation.
+
+Functions
+---------
+build_projection_matrix
+    Build a 3×4 camera projection matrix from intrinsics and extrinsics.
+undistort_points
+    Undistort 2D keypoints using OpenCV radial/tangential model.
+triangulate_points_dlt
+    Triangulate 3D positions from ≥2 camera views using DLT / SVD.
+triangulate_pose_df
+    Full pipeline: per-camera 2D DataFrames → 3D MultiIndex DataFrame.
+compute_reprojection_errors
+    Compute per-camera reprojection error for triangulated 3D points.
+reproject_pose_to_camera
+    Reproject a triangulated 3D pose into one camera as a DLC-style 2D
+    DataFrame (inverse of ``triangulate_pose_df``); closes the 2D→3D→2D loop.
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+def build_projection_matrix(intrinsics: dict, extrinsics: dict) -> np.ndarray:
+    """Build a 3×4 camera projection matrix P = K @ [R | t].
+
+    Parameters
+    ----------
+    intrinsics : dict
+        Keys: ``fx``, ``fy``, ``cx``, ``cy``.
+    extrinsics : dict
+        Keys: ``R`` (3×3 rotation, camera-to-rig) and ``t`` (3-vector,
+        camera-to-rig translation in metres).
+
+    Returns
+    -------
+    np.ndarray
+        Shape (3, 4) projection matrix.
+
+    Notes
+    -----
+    Extrinsics are stored camera-to-rig (world).  The projection matrix
+    requires rig-to-camera, so we invert: R_wc = R.T, t_wc = -R.T @ t.
+    """
+    K = np.array(
+        [
+            [intrinsics["fx"], 0.0, intrinsics["cx"]],
+            [0.0, intrinsics["fy"], intrinsics["cy"]],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    R_cw = np.array(extrinsics["R"]).T  # camera-to-rig → rig-to-camera
+    t_cw = -R_cw @ np.array(extrinsics["t"])
+    Rt = np.hstack([R_cw, t_cw.reshape(3, 1)])
+    return K @ Rt
+
+
+def undistort_points(
+    pts: np.ndarray,
+    intrinsics: dict,
+) -> np.ndarray:
+    """Undistort 2D points using OpenCV's radial/tangential model.
+
+    Parameters
+    ----------
+    pts : np.ndarray
+        Shape (n, 2) array of (x, y) pixel coordinates.  May contain NaN.
+    intrinsics : dict
+        Keys: ``fx``, ``fy``, ``cx``, ``cy``, ``dist_coeffs`` (4-element
+        list ``[k1, k2, p1, p2]``).
+
+    Returns
+    -------
+    np.ndarray
+        Shape (n, 2) undistorted pixel coordinates.  NaN rows are preserved.
+    """
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError(
+            "opencv-python is required for undistortion. "
+            "Install with: pip install opencv-python"
+        ) from exc
+
+    K = np.array(
+        [
+            [intrinsics["fx"], 0.0, intrinsics["cx"]],
+            [0.0, intrinsics["fy"], intrinsics["cy"]],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    dist = np.array(intrinsics.get("dist_coeffs", [0.0, 0.0, 0.0, 0.0]))
+
+    valid = ~np.isnan(pts[:, 0])
+    out = pts.copy()
+    if np.any(valid):
+        pts_valid = pts[valid].reshape(-1, 1, 2).astype(np.float64)
+        undist = cv2.undistortPoints(pts_valid, K, dist, P=K)
+        out[valid] = undist.reshape(-1, 2)
+    return out
+
+
+def triangulate_points_dlt(
+    pts_list: List[np.ndarray],
+    proj_matrices: List[np.ndarray],
+) -> np.ndarray:
+    """Triangulate a set of corresponding 2D points from ≥2 cameras via DLT.
+
+    For each frame, constructs a linear system from all camera observations
+    and solves via SVD (Direct Linear Transform).  Frames where any camera
+    has NaN observations are returned as NaN.
+
+    Parameters
+    ----------
+    pts_list : list of np.ndarray
+        Each element has shape (n_frames, 2) — pixel (x, y) for one camera.
+        NaN indicates missing detection for that frame.
+    proj_matrices : list of np.ndarray
+        Each element has shape (3, 4) — projection matrix for the same camera.
+
+    Returns
+    -------
+    np.ndarray
+        Shape (n_frames, 3) — triangulated (X, Y, Z) in rig coordinates
+        (units match the extrinsics translation, typically metres).
+        Frames with insufficient valid cameras are NaN.
+    """
+    n_frames = pts_list[0].shape[0]
+    pts3d = np.full((n_frames, 3), np.nan)
+
+    for i in range(n_frames):
+        rows = []
+        for pts, P in zip(pts_list, proj_matrices):
+            x, y = pts[i]
+            if np.isnan(x) or np.isnan(y):
+                continue
+            rows.append(x * P[2] - P[0])
+            rows.append(y * P[2] - P[1])
+
+        if len(rows) < 4:  # need at least 2 cameras (4 equations)
+            continue
+
+        A = np.stack(rows)  # (2*n_cams, 4)
+        _, _, Vt = np.linalg.svd(A)
+        X = Vt[-1]
+        if abs(X[3]) < 1e-12:
+            continue
+        pts3d[i] = X[:3] / X[3]
+
+    return pts3d
+
+
+def compute_reprojection_errors(
+    pts3d: np.ndarray,
+    pts_list: List[np.ndarray],
+    proj_matrices: List[np.ndarray],
+) -> np.ndarray:
+    """Compute mean reprojection error (pixels) per frame across cameras.
+
+    Parameters
+    ----------
+    pts3d : np.ndarray
+        Shape (n_frames, 3) triangulated 3D points.
+    pts_list : list of np.ndarray
+        Per-camera 2D observations, each (n_frames, 2).
+    proj_matrices : list of np.ndarray
+        Per-camera projection matrices, each (3, 4).
+
+    Returns
+    -------
+    np.ndarray
+        Shape (n_frames,) mean reprojection error in pixels.  Frames with
+        no valid triangulation are NaN.
+    """
+    n_frames = pts3d.shape[0]
+    errors = np.full(n_frames, np.nan)
+
+    for i in range(n_frames):
+        if np.isnan(pts3d[i, 0]):
+            continue
+        X_h = np.append(pts3d[i], 1.0)
+        cam_errors = []
+        for pts, P in zip(pts_list, proj_matrices):
+            x2d, y2d = pts[i]
+            if np.isnan(x2d):
+                continue
+            proj = P @ X_h
+            if abs(proj[2]) < 1e-12:
+                continue
+            px = proj[0] / proj[2]
+            py = proj[1] / proj[2]
+            cam_errors.append(np.sqrt((px - x2d) ** 2 + (py - y2d) ** 2))
+        if cam_errors:
+            errors[i] = float(np.mean(cam_errors))
+
+    return errors
+
+
+def triangulate_pose_df(
+    cam_dfs: Dict[int, pd.DataFrame],
+    cam_calibrations: Dict[int, dict],
+    bodyparts: List[str],
+    min_confidence: float = 0.6,
+    max_reproj_error: float = 5.0,
+) -> pd.DataFrame:
+    """Triangulate per-bodypart 3D positions from multiple camera 2D DataFrames.
+
+    Parameters
+    ----------
+    cam_dfs : dict
+        Mapping from camera_index to a 2-level MultiIndex DataFrame
+        ``(bodypart, coord)`` with columns ``x``, ``y``, ``likelihood``
+        for each bodypart.
+    cam_calibrations : dict
+        Mapping from camera_index to ``{"intrinsics": ..., "extrinsics": ...}``.
+    bodyparts : list of str
+        Bodypart names to triangulate.
+    min_confidence : float, optional
+        Per-camera likelihood threshold.  Frames below this are treated as
+        missing for that camera.  Default 0.6.
+    max_reproj_error : float, optional
+        Maximum allowed mean reprojection error in pixels.  Frames exceeding
+        this threshold have their 3D likelihood set to 0.  Default 5.0.
+
+    Returns
+    -------
+    pd.DataFrame
+        MultiIndex DataFrame with 3-level columns ``(scorer, bodypart, coord)``
+        where ``scorer = "triangulated"`` and ``coord ∈ {x, y, z, likelihood}``.
+        Index is shared with the input DataFrames.
+    """
+    cam_indices = sorted(cam_dfs.keys())
+    if len(cam_indices) < 2:
+        raise ValueError("Need at least 2 cameras for triangulation.")
+
+    proj_matrices = {
+        ci: build_projection_matrix(
+            cam_calibrations[ci]["intrinsics"],
+            cam_calibrations[ci]["extrinsics"],
+        )
+        for ci in cam_indices
+    }
+
+    index = next(iter(cam_dfs.values())).index
+
+    records: dict = {}
+    for bp in bodyparts:
+        pts_list = []
+        undist_list = []
+        for ci in cam_indices:
+            df = cam_dfs[ci]
+            x = df[(bp, "x")].values.copy()
+            y = df[(bp, "y")].values.copy()
+            like = df[(bp, "likelihood")].values
+            # Mask low-confidence frames.
+            low = like < min_confidence
+            x[low] = np.nan
+            y[low] = np.nan
+            pts_raw = np.column_stack([x, y])
+            pts_undist = undistort_points(
+                pts_raw, cam_calibrations[ci]["intrinsics"]
+            )
+            pts_list.append(pts_raw)
+            undist_list.append(pts_undist)
+
+        pts3d = triangulate_points_dlt(
+            undist_list,
+            [proj_matrices[ci] for ci in cam_indices],
+        )
+
+        reproj = compute_reprojection_errors(
+            pts3d,
+            pts_list,
+            [proj_matrices[ci] for ci in cam_indices],
+        )
+
+        likelihood_3d = np.where(
+            np.isnan(pts3d[:, 0]),
+            np.nan,
+            np.where(reproj > max_reproj_error, 0.0, 1.0),
+        )
+
+        records[(bp, "x")] = pts3d[:, 0]
+        records[(bp, "y")] = pts3d[:, 1]
+        records[(bp, "z")] = pts3d[:, 2]
+        records[(bp, "likelihood")] = likelihood_3d
+
+    df_out = pd.DataFrame(records, index=index)
+    df_out.columns = pd.MultiIndex.from_tuples(
+        [("triangulated", bp, coord) for bp, coord in df_out.columns],
+        names=["scorer", "bodypart", "coords"],
+    )
+    return df_out
+
+
+def reproject_pose_to_camera(
+    pose_3d: pd.DataFrame,
+    calibration: dict,
+    bodyparts: Optional[List[str]] = None,
+    scale: float = 1.0,
+    scorer_in: str = "triangulated",
+    scorer_out: str = "reprojected3d",
+    out_h5: Optional[str] = None,
+) -> pd.DataFrame:
+    """Reproject a triangulated 3D pose into one camera's image plane.
+
+    This is the inverse of :func:`triangulate_pose_df`: it maps 3D rig-frame
+    points back through a single camera's projection matrix to pixel (u, v)
+    coordinates, producing a DeepLabCut-style 2D DataFrame.  Overlaying the
+    result on the source video closes the 2D → 3D → 2D loop and validates the
+    triangulation and calibration.
+
+    Parameters
+    ----------
+    pose_3d : pd.DataFrame
+        Triangulated 3D pose with 3-level columns ``(scorer, bodypart, coord)``
+        where ``coord ∈ {x, y, z, likelihood}`` — the output of
+        :func:`triangulate_pose_df` (or ``PoseEstim.fetch1_dataframe``).
+    calibration : dict
+        Single-camera calibration ``{"intrinsics": ..., "extrinsics": ...}``,
+        as consumed by :func:`build_projection_matrix`.
+    bodyparts : list of str, optional
+        Bodyparts to reproject.  Defaults to every bodypart present under
+        ``scorer_in`` in ``pose_3d``.
+    scale : float, optional
+        Divisor applied to the stored 3D coordinates to convert them into the
+        units of the extrinsics translation (metres).  Use ``100.0`` when the
+        pose is stored in centimetres.  Default ``1.0`` (already in metres).
+    scorer_in : str, optional
+        Scorer level to read from ``pose_3d``.  Default ``"triangulated"``.
+    scorer_out : str, optional
+        Scorer level written to the returned DataFrame.  Default
+        ``"reprojected3d"``.
+    out_h5 : str or path-like, optional
+        If given, also write the result to a DLC-style HDF5 file (key
+        ``"df_with_missing"``) at this path.
+
+    Returns
+    -------
+    pd.DataFrame
+        DLC-style 2D pose with 3-level columns
+        ``(scorer_out, bodypart, coord)`` where ``coord ∈ {x, y, likelihood}``.
+        Points that project behind the camera (or came from a NaN 3D point)
+        have their likelihood set to 0.  Index is shared with ``pose_3d``.
+    """
+    proj_mat = build_projection_matrix(
+        calibration["intrinsics"], calibration["extrinsics"]
+    )
+    if bodyparts is None:
+        bodyparts = list(
+            dict.fromkeys(pose_3d[scorer_in].columns.get_level_values(0))
+        )
+
+    data: dict = {}
+    for bp in bodyparts:
+        xyz = pose_3d[scorer_in][bp][["x", "y", "z"]].to_numpy() / scale
+        conf = pose_3d[scorer_in][bp]["likelihood"].to_numpy()
+        hom = np.column_stack([xyz, np.ones(len(xyz))])
+        px = (proj_mat @ hom.T).T
+        with np.errstate(invalid="ignore", divide="ignore"):
+            u = px[:, 0] / px[:, 2]
+            v = px[:, 1] / px[:, 2]
+        conf = np.where(np.isnan(u), 0.0, np.nan_to_num(conf, nan=0.0))
+        data[(scorer_out, bp, "x")] = u
+        data[(scorer_out, bp, "y")] = v
+        data[(scorer_out, bp, "likelihood")] = conf
+
+    out = pd.DataFrame(data, index=pose_3d.index)
+    out.columns = pd.MultiIndex.from_tuples(
+        list(out.columns), names=["scorer", "bodyparts", "coords"]
+    )
+    if out_h5 is not None:
+        out.to_hdf(str(out_h5), key="df_with_missing", mode="w")
+    return out

--- a/src/spyglass/position/v2/utils/triangulation.py
+++ b/src/spyglass/position/v2/utils/triangulation.py
@@ -93,7 +93,9 @@ def undistort_points(
     )
     dist = np.array(intrinsics.get("dist_coeffs", [0.0, 0.0, 0.0, 0.0]))
 
-    valid = ~np.isnan(pts[:, 0])
+    # A point is usable only if both coordinates are present; sending a
+    # partially-missing point to OpenCV would break NaN-row preservation.
+    valid = ~np.isnan(pts).any(axis=1)
     out = pts.copy()
     if np.any(valid):
         pts_valid = pts[valid].reshape(-1, 1, 2).astype(np.float64)
@@ -108,9 +110,10 @@ def triangulate_points_dlt(
 ) -> np.ndarray:
     """Triangulate a set of corresponding 2D points from ≥2 cameras via DLT.
 
-    For each frame, constructs a linear system from all camera observations
-    and solves via SVD (Direct Linear Transform).  Frames where any camera
-    has NaN observations are returned as NaN.
+    For each frame, constructs a linear system from all *valid* (non-NaN)
+    camera observations and solves via SVD (Direct Linear Transform).
+    Cameras with a NaN observation are skipped; a frame is returned as NaN
+    only when fewer than two cameras remain valid.
 
     Parameters
     ----------
@@ -184,7 +187,7 @@ def compute_reprojection_errors(
         cam_errors = []
         for pts, P in zip(pts_list, proj_matrices):
             x2d, y2d = pts[i]
-            if np.isnan(x2d):
+            if np.isnan(x2d) or np.isnan(y2d):
                 continue
             proj = P @ X_h
             if abs(proj[2]) < 1e-12:
@@ -270,9 +273,12 @@ def triangulate_pose_df(
             [proj_matrices[ci] for ci in cam_indices],
         )
 
+        # Reproject against the *undistorted* 2D points: the projection
+        # matrices are pinhole (no distortion), so comparing to raw distorted
+        # points would inflate the error and wrongly zero out likelihood.
         reproj = compute_reprojection_errors(
             pts3d,
-            pts_list,
+            undist_list,
             [proj_matrices[ci] for ci in cam_indices],
         )
 
@@ -290,7 +296,7 @@ def triangulate_pose_df(
     df_out = pd.DataFrame(records, index=index)
     df_out.columns = pd.MultiIndex.from_tuples(
         [("triangulated", bp, coord) for bp, coord in df_out.columns],
-        names=["scorer", "bodypart", "coords"],
+        names=["scorer", "bodyparts", "coords"],
     )
     return df_out
 
@@ -362,6 +368,11 @@ def reproject_pose_to_camera(
         with np.errstate(invalid="ignore", divide="ignore"):
             u = px[:, 0] / px[:, 2]
             v = px[:, 1] / px[:, 2]
+        # Points at or behind the camera (depth <= 0) are invalid even though
+        # u/v are finite; drop them so their likelihood becomes 0.
+        behind = px[:, 2] <= 0
+        u = np.where(behind, np.nan, u)
+        v = np.where(behind, np.nan, v)
         conf = np.where(np.isnan(u), 0.0, np.nan_to_num(conf, nan=0.0))
         data[(scorer_out, bp, "x")] = u
         data[(scorer_out, bp, "y")] = v

--- a/tests/position/v2/anipose_example.py
+++ b/tests/position/v2/anipose_example.py
@@ -1,0 +1,255 @@
+"""Fetch + prepare the Anipose mouse example data for the 3D tutorial.
+
+Notebook ``24_PositionV2_DLC_3D`` triangulates a two-camera mouse-reaching
+trial from the `Anipose paper <https://doi.org/10.5061/dryad.nzs7h44s4>`_
+(Karashchuk et al. 2021). That dataset ships as a single ~942 MB Zenodo zip,
+and using it requires three pieces of dataset-specific plumbing that would
+otherwise clutter the tutorial:
+
+1. **Download** the archive once (with disk / partial-file / corruption guards).
+2. **Extract** only the handful of members one reaching trial needs.
+3. **Reshape** Anipose's multi-candidate 2D detections into the tidy,
+   single-detection DLC-style ``.h5`` the V2 ``task_mode='load'`` path expects.
+
+:func:`fetch_anipose_example` performs all three and returns the resolved paths
+the notebook consumes, so the tutorial itself is left with only the
+user-facing, swappable steps (calibration conversion, video registration,
+running ``PoseEstim``, plotting).
+
+.. note::
+   This lives under ``tests/`` alongside the other tutorial bootstrap helpers
+   (``make_example_dlc_project.py``, ``make_example_3d_project.py``) even
+   though it fetches example rather than test data — a deliberate tradeoff to
+   keep every notebook-support helper co-located and importable the same way.
+"""
+
+import os
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Dataset facts (the Anipose mouse two-camera reaching trial)
+# ---------------------------------------------------------------------------
+
+ZENODO_URL = (
+    "https://zenodo.org/api/records/5733431/files/mouse-anipose.zip/content"
+)
+
+# One reaching trial from one session of the two-camera mouse project.
+ZIP_SESS = "mouse-testing/020820_preDTreaches_day1/020820_JiDT13"
+REACH = "preDT1_JiDT13_reach1_hit"
+CAM_TOKENS = ["cam1", "cam2"]  # camera-name tokens used in file names
+
+# The keypoints this dataset ships. Registered in ``BodyPart.contents`` so the
+# tutorial does not silently create non-canonical parts.
+BODYPARTS = ["l-base", "l-edge", "l-middle", "r-base", "r-edge", "r-middle"]
+EDGES = [
+    ("l-base", "l-edge"),
+    ("l-edge", "l-middle"),
+    ("l-middle", "l-base"),
+    ("r-base", "r-edge"),
+    ("r-edge", "r-middle"),
+    ("r-middle", "r-base"),
+]
+
+
+def _needed_members():
+    """Return the minimal set of zip members one reaching trial needs."""
+    members = [
+        f"{ZIP_SESS}/calibration/calibration.toml",
+        f"{ZIP_SESS}/pose-3d/{REACH}.csv",
+    ]
+    for tok in CAM_TOKENS:
+        members += [
+            f"{ZIP_SESS}/pose-2d/{REACH}_{tok}.h5",
+            f"{ZIP_SESS}/videos-raw/{REACH}_{tok}.mp4",
+        ]
+    return members
+
+
+def _download_and_extract(dest_dir):
+    """Download (once) and extract only the members this trial needs.
+
+    Verifies each needed member exists in the archive and is non-empty after
+    extraction, and cleans up a partial/corrupt download so a re-run can retry.
+
+    Parameters
+    ----------
+    dest_dir : Path
+        Directory that holds the downloaded zip and its ``extracted`` tree.
+
+    Returns
+    -------
+    Path
+        The extracted session directory (``extracted/<ZIP_SESS>``).
+    """
+    mouse_zip = dest_dir / "mouse-anipose.zip"
+    extract_root = dest_dir / "extracted"
+    needed = _needed_members()
+
+    missing = [m for m in needed if not (extract_root / m).exists()]
+    if missing:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        if not mouse_zip.exists() or mouse_zip.stat().st_size == 0:
+            import urllib.request
+
+            print(f"Downloading mouse-anipose.zip (~942 MB) to {mouse_zip} ...")
+            print(
+                "One-time download; ensure ~2 GB free for the zip + extracts."
+            )
+            try:
+                urllib.request.urlretrieve(ZENODO_URL, mouse_zip)
+            except Exception as err:  # network failure, disk full, ...
+                mouse_zip.unlink(missing_ok=True)  # don't leave a partial file
+                raise RuntimeError(
+                    f"Download of {ZENODO_URL} failed ({err}). Re-run to "
+                    "retry, or set ANIPOSE_DIR / dest_dir to a pre-downloaded "
+                    "copy."
+                ) from err
+        if mouse_zip.stat().st_size == 0:
+            mouse_zip.unlink(missing_ok=True)
+            raise RuntimeError(
+                "Downloaded zip is empty — the download was incomplete. "
+                "Re-run to retry."
+            )
+
+        print(f"Extracting {len(missing)} needed file(s) ...")
+        try:
+            with zipfile.ZipFile(mouse_zip) as zf:
+                names = set(zf.namelist())
+                absent = [m for m in missing if m not in names]
+                if absent:
+                    raise KeyError(
+                        "Expected files are not in the archive:\n  "
+                        + "\n  ".join(absent)
+                        + "\nThe dataset layout may have changed."
+                    )
+                for member in missing:
+                    zf.extract(member, extract_root)
+        except zipfile.BadZipFile as err:
+            mouse_zip.unlink(missing_ok=True)  # corrupt — force re-download
+            raise RuntimeError(
+                "The downloaded zip is corrupt (likely a partial download). "
+                "It has been removed; re-run to download again."
+            ) from err
+
+        for member in missing:
+            out = extract_root / member
+            if not out.exists() or out.stat().st_size == 0:
+                raise RuntimeError(f"Extracted file is missing or empty: {out}")
+        print("Done.")
+    else:
+        print("Example data already present — skipping download.")
+
+    return extract_root / ZIP_SESS
+
+
+def _write_clean_dlc_h5(pose2d_h5, out_h5):
+    """Reshape one Anipose 2D ``.h5`` into a tidy DLC-style ``.h5``.
+
+    Anipose stores multiple candidate detections per body part; this keeps the
+    top ``x`` / ``y`` / ``likelihood`` per part and writes a 3-level
+    ``(scorer, bodyparts, coords)`` frame — the layout the V2 DLC output-
+    discovery strategy expects for ``task_mode='load'``.
+
+    Parameters
+    ----------
+    pose2d_h5 : Path
+        Source Anipose ``pose-2d`` ``.h5`` for one camera.
+    out_h5 : Path
+        Destination path for the cleaned DLC-style ``.h5``.
+
+    Returns
+    -------
+    Path
+        ``out_h5``.
+    """
+    raw = pd.read_hdf(pose2d_h5)
+    scorer = raw.columns.get_level_values("scorer")[0]
+    flat = raw[scorer]
+    cols, data = [], {}
+    for bp in BODYPARTS:
+        for coord in ("x", "y", "likelihood"):
+            cols.append((scorer, bp, coord))
+            data[(scorer, bp, coord)] = flat[(bp, coord)].values
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(
+        cols, names=["scorer", "bodyparts", "coords"]
+    )
+    df.to_hdf(str(out_h5), key="df_with_missing", mode="w")
+    return out_h5
+
+
+def fetch_anipose_example(dest_dir=None):
+    """Fetch + prepare the Anipose mouse example data for tutorial 24.
+
+    Downloads the dataset zip once, extracts the members one reaching trial
+    needs, and reshapes the per-camera Anipose 2D detections into tidy
+    DLC-style ``.h5`` files. Everything returned is a resolved path the
+    notebook feeds straight into the user-facing pipeline steps.
+
+    Parameters
+    ----------
+    dest_dir : str or Path, optional
+        Where the data lives. Defaults to the ``ANIPOSE_DIR`` environment
+        variable, or ``~/spyglass_data/anipose`` if that is unset. Point it at
+        an existing copy to skip the download.
+
+    Returns
+    -------
+    dict
+        Resolved paths and dataset metadata:
+
+        ``session_dir`` : Path
+            The extracted session directory (root of the trial's files).
+        ``calibration_toml`` : Path
+            Anipose ``calibration.toml`` (the calibration source the notebook
+            converts into V2 ``Calibration`` dicts).
+        ``reference_3d`` : Path
+            Anipose's own ``pose-3d`` CSV, for validating V2 triangulation.
+        ``videos`` : dict
+            ``{camera_token: Path}`` raw per-camera reach video.
+        ``pose_2d`` : dict
+            ``{camera_token: Path}`` cleaned DLC-style 2D-detection ``.h5``.
+        ``camera_tokens`` : list of str
+            Camera-name tokens (``["cam1", "cam2"]``); each token appears in
+            its camera's video / detection file names.
+        ``reach`` : str
+            The reaching-trial stem.
+        ``bodyparts`` : list of str
+            The dataset's keypoint names.
+        ``edges`` : list of (str, str)
+            Skeleton edges among ``bodyparts``.
+    """
+    if dest_dir is None:
+        dest_dir = os.environ.get(
+            "ANIPOSE_DIR", Path.home() / "spyglass_data" / "anipose"
+        )
+    dest_dir = Path(dest_dir)
+
+    session_dir = _download_and_extract(dest_dir)
+
+    detections_dir = session_dir / "example_2d_detections"
+    detections_dir.mkdir(exist_ok=True)
+
+    videos, pose_2d = {}, {}
+    for tok in CAM_TOKENS:
+        videos[tok] = session_dir / "videos-raw" / f"{REACH}_{tok}.mp4"
+        pose_2d[tok] = _write_clean_dlc_h5(
+            session_dir / "pose-2d" / f"{REACH}_{tok}.h5",
+            detections_dir / f"{REACH}_{tok}_clean.h5",
+        )
+
+    return {
+        "session_dir": session_dir,
+        "calibration_toml": session_dir / "calibration" / "calibration.toml",
+        "reference_3d": session_dir / "pose-3d" / f"{REACH}.csv",
+        "videos": videos,
+        "pose_2d": pose_2d,
+        "camera_tokens": list(CAM_TOKENS),
+        "reach": REACH,
+        "bodyparts": list(BODYPARTS),
+        "edges": [tuple(e) for e in EDGES],
+    }

--- a/tests/position/v2/make_example_3d_project.py
+++ b/tests/position/v2/make_example_3d_project.py
@@ -1,0 +1,405 @@
+"""Bootstrap dummy upstream entries for a multi-camera (3D) Position V2 project.
+
+This is the 3D analogue of ``make_example_dlc_project.py``.  Where that helper
+wires up a single-camera DLC project, this one creates every upstream row the
+V2 3D triangulation path needs so that ``PoseEstim.populate()`` runs in 3D
+mode (``task_mode='load'``) over per-camera DLC ``.h5`` outputs already on disk:
+
+    CameraDevice -> CameraRig(.Camera) -> Calibration(.Camera)
+    BodyPart -> Skeleton -> ModelParams -> ModelSelection -> Model
+    Nwbfile/Session/Task/IntervalList/TaskEpoch -> VideoFile
+    VidFileGroup(.File[camera_index], .Calibration)
+    PoseEstimParams -> PoseEstimSelection(task_mode='load')
+
+The caller supplies the *real* per-camera inputs (DLC h5 outputs, videos, and
+calibration); everything else is synthetic scaffolding.  The 2D inputs and
+calibration are produced by a dataset-specific preparer — e.g.
+``maintenance_scripts/load_anipose_3d_project.py`` for the Anipose mouse data.
+
+The per-camera DLC ``.h5`` files must be named ``{video_stem}DLC_*.h5`` and
+live in ``output_dir`` so the DLC output-discovery strategy finds them
+(``DLCStrategy.find_output_files``).
+
+All identifiers are derived from ``prefix`` (default ``"anipose3d"``) so a run
+can be torn down with :func:`cleanup_3d_project`.  Requires an active Spyglass
+database connection.
+
+If you use this on a shared database, **please call cleanup_3d_project() when
+you are done.**
+"""
+
+import shutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+
+def bootstrap_3d_project(
+    video_paths,
+    output_dir,
+    calib_by_cam,
+    bodyparts,
+    edges,
+    scorer,
+    camera_indices=None,
+    prefix="anipose3d",
+    min_confidence=0.3,
+    max_reproj_error=5.0,
+    description="Anipose 3D integration test",
+):
+    """Insert all upstream entries needed to populate ``PoseEstim`` in 3D mode.
+
+    Parameters
+    ----------
+    video_paths : list of str or Path
+        One real video per camera, in camera-index order.  Each video's frame
+        count must match the row count of its paired DLC ``.h5`` so per-frame
+        timestamps line up (the 3D path derives timestamps from the video when
+        the NWB object IDs are synthetic).
+    output_dir : str or Path
+        Directory holding the per-camera ``{video_stem}DLC_*.h5`` files and
+        used as ``PoseEstimSelection.output_dir``.
+    calib_by_cam : dict
+        Mapping ``camera_index -> {"intrinsics": dict, "extrinsics": dict,
+        "image_size": [w, h]}``.  ``extrinsics["t"]`` must be in **metres**
+        (the 3D path scales triangulated coordinates by 100 to centimetres).
+    bodyparts : list of str
+        Body part names matching the DLC ``.h5`` columns.
+    edges : list of (str, str)
+        Skeleton edges among ``bodyparts``.
+    scorer : str
+        DLC scorer string (informational; stored on the model path).
+    camera_indices : list of int, optional
+        Camera slot per video.  Defaults to ``[0, 1, ...]`` in input order.
+    prefix : str, optional
+        Identifier prefix for all created rows.  Default ``"anipose3d"``.
+    min_confidence, max_reproj_error : float, optional
+        Triangulation thresholds stored in ``PoseEstimParams`` and read by
+        ``PoseEstim._make_3d``.  Defaults match the Anipose mouse config
+        (0.3, 5.0).
+    description : str, optional
+        Free-text description for the session / video group.
+
+    Returns
+    -------
+    dict
+        ``{"selection_key", "model_id", "vid_group_id", "camera_rig_id",
+        "calibration_id", "skeleton_id", "nwb_file_name", "prefix"}``.
+    """
+    from spyglass.common import (
+        IntervalList,
+        Nwbfile,
+        Session,
+        Task,
+        TaskEpoch,
+        VideoFile,
+    )
+    from spyglass.common.common_device import CameraDevice
+    from spyglass.position.v2.estim import PoseEstimParams, PoseEstimSelection
+    from spyglass.position.v2.train import (
+        BodyPart,
+        Model,
+        ModelParams,
+        ModelSelection,
+        Skeleton,
+    )
+    from spyglass.position.v2.video import Calibration, CameraRig, VidFileGroup
+    from spyglass.settings import raw_dir
+
+    video_paths = [str(Path(v).resolve()) for v in video_paths]
+    n_cams = len(video_paths)
+    if camera_indices is None:
+        camera_indices = list(range(n_cams))
+    if len(camera_indices) != n_cams:
+        raise ValueError(
+            f"camera_indices ({len(camera_indices)}) must match the number "
+            f"of videos ({n_cams})."
+        )
+    # Every loaded video must pair with a calibrated camera at the same slot,
+    # and every calibrated camera must have a video — otherwise the 3D path
+    # would triangulate a camera against the wrong (or a missing) calibration.
+    if set(camera_indices) != set(calib_by_cam):
+        raise ValueError(
+            "Loaded videos are not paired 1:1 with calibrations: video "
+            f"camera_indices {sorted(set(camera_indices))} != calibration "
+            f"camera_indices {sorted(calib_by_cam)}."
+        )
+    output_dir = str(Path(output_dir).resolve())
+
+    ins = dict(allow_direct_insert=True, skip_duplicates=True)
+
+    # ---- Session scaffolding (NWB placeholder = copy of minirec) ----------
+    nwb_file_name = f"{prefix}_.nwb"
+    nwb_path = Path(raw_dir) / nwb_file_name
+    if not nwb_path.exists() or nwb_path.stat().st_size == 0:
+        minirec = Path(raw_dir) / "minirec20230622_.nwb"
+        if minirec.exists():
+            shutil.copy2(str(minirec), str(nwb_path))
+        else:  # pragma: no cover - environments without the mini test file
+            nwb_path.touch()
+
+    task_name = f"{prefix}_task"
+    interval_name = f"{prefix}_epoch_1"
+    now = datetime.now()
+
+    if not (Nwbfile() & {"nwb_file_name": nwb_file_name}):
+        Nwbfile().insert1(
+            {
+                "nwb_file_name": nwb_file_name,
+                "nwb_file_abs_path": str(nwb_path.resolve()),
+            },
+            allow_direct_insert=True,
+        )
+    Session().insert1(
+        {
+            "nwb_file_name": nwb_file_name,
+            "session_description": description,
+            "session_start_time": now,
+            "timestamps_reference_time": now,
+        },
+        **ins,
+    )
+    Task().insert1({"task_name": task_name}, **ins)
+    IntervalList().insert1(
+        {
+            "nwb_file_name": nwb_file_name,
+            "interval_list_name": interval_name,
+            "valid_times": np.array([[0.0, 1.0]]),
+        },
+        **ins,
+    )
+    TaskEpoch().insert1(
+        {
+            "nwb_file_name": nwb_file_name,
+            "epoch": 1,
+            "task_name": task_name,
+            "interval_list_name": interval_name,
+            "camera_names": [],
+        },
+        **ins,
+    )
+
+    # ---- Per-camera VideoFile + CameraDevice ------------------------------
+    cam_names = {}
+    vf_keys = []
+    for ci, vp in zip(camera_indices, video_paths):
+        cam_name = f"{prefix}_cam{ci}"
+        cam_names[ci] = cam_name
+        CameraDevice.insert1(
+            {"camera_name": cam_name, "meters_per_pixel": 0.0},
+            skip_duplicates=True,
+        )
+        vf_pk = {
+            "nwb_file_name": nwb_file_name,
+            "epoch": 1,
+            "video_file_num": ci,
+        }
+        if VideoFile & vf_pk:
+            VideoFile.update1({**vf_pk, "path": vp})
+        else:
+            VideoFile().insert1(
+                {
+                    **vf_pk,
+                    "camera_name": cam_name,
+                    "video_file_object_id": str(uuid.uuid4())[:40],
+                    "path": vp,
+                },
+                allow_direct_insert=True,
+            )
+        vf_keys.append(vf_pk)
+
+    # ---- Camera rig + calibration -----------------------------------------
+    camera_rig_id = f"{prefix}_rig"
+    calibration_id = f"{prefix}_cal"
+    CameraRig.insert1(
+        {
+            "camera_rig_id": camera_rig_id,
+            "description": description,
+            "n_cameras": n_cams,
+        },
+        skip_duplicates=True,
+    )
+    for ci in camera_indices:
+        CameraRig.Camera.insert1(
+            {
+                "camera_rig_id": camera_rig_id,
+                "camera_index": ci,
+                "camera_name": cam_names[ci],
+            },
+            skip_duplicates=True,
+        )
+    Calibration.insert1(
+        {
+            "camera_rig_id": camera_rig_id,
+            "calibration_id": calibration_id,
+            "calibration_date": now.date().isoformat(),
+            "notes": description,
+        },
+        skip_duplicates=True,
+    )
+    for ci in camera_indices:
+        cam_cal = calib_by_cam[ci]
+        Calibration.Camera.insert1(
+            {
+                "camera_rig_id": camera_rig_id,
+                "calibration_id": calibration_id,
+                "camera_index": ci,
+                "intrinsics": cam_cal["intrinsics"],
+                "extrinsics": cam_cal["extrinsics"],
+                "image_size": list(cam_cal["image_size"]),
+            },
+            skip_duplicates=True,
+        )
+
+    # ---- Video group (camera_index) + calibration link --------------------
+    vid_group_id = f"{prefix}_grp"
+    VidFileGroup().insert1(
+        {
+            "vid_group_id": vid_group_id,
+            "description": description,
+            "files": vf_keys,
+            "camera_indices": list(camera_indices),
+        }
+    )
+    VidFileGroup.Calibration().insert1(
+        {
+            "vid_group_id": vid_group_id,
+            "camera_rig_id": camera_rig_id,
+            "calibration_id": calibration_id,
+        },
+        skip_duplicates=True,
+    )
+
+    # ---- Skeleton + Model chain -------------------------------------------
+    skeleton_id = f"{prefix}_skel"
+    if not (Skeleton() & {"skeleton_id": skeleton_id}):
+        Skeleton().insert1(
+            {
+                "skeleton_id": skeleton_id,
+                "bodyparts": list(bodyparts),
+                "edges": [tuple(e) for e in edges],
+            },
+            accept_new_bodyparts=True,
+        )
+
+    mp_result = ModelParams().insert1(
+        {
+            "model_params_id": f"{prefix}_mp",
+            "tool": "DLC",
+            "params": {
+                "project_path": output_dir,
+                "shuffle": 1,
+                "trainingsetindex": 0,
+            },
+            "skeleton_id": skeleton_id,
+        },
+        skip_duplicates=True,
+    )
+    model_params_id = mp_result["model_params_id"]
+
+    model_selection_id = f"{prefix}_sel"
+    ModelSelection().insert1(
+        {
+            "model_params_id": model_params_id,
+            "tool": "DLC",
+            "vid_group_id": vid_group_id,
+            "model_selection_id": model_selection_id,
+        },
+        skip_duplicates=True,
+    )
+
+    model_id = f"{prefix}_model"
+    Model().insert1(
+        {
+            "model_id": model_id,
+            "model_params_id": model_params_id,
+            "tool": "DLC",
+            "vid_group_id": vid_group_id,
+            "model_selection_id": model_selection_id,
+            "model_path": scorer,
+        },
+        allow_direct_insert=True,
+        skip_duplicates=True,
+    )
+
+    # ---- Pose estimation selection (load mode) ----------------------------
+    params_key = PoseEstimParams.insert_params(
+        {
+            "min_confidence": float(min_confidence),
+            "max_reproj_error": float(max_reproj_error),
+        },
+        params_id=f"{prefix}_pep",
+        skip_duplicates=True,
+    )
+    selection_key = PoseEstimSelection().insert_estimation_task(
+        {
+            "model_id": model_id,
+            "vid_group_id": vid_group_id,
+            "pose_estim_params_id": params_key["pose_estim_params_id"],
+        },
+        task_mode="load",
+        output_dir=output_dir,
+        skip_duplicates=True,
+    )
+    selection_key = {
+        k: selection_key[k]
+        for k in ("model_id", "vid_group_id", "pose_estim_params_id")
+    }
+
+    return {
+        "selection_key": selection_key,
+        "model_id": model_id,
+        "vid_group_id": vid_group_id,
+        "camera_rig_id": camera_rig_id,
+        "calibration_id": calibration_id,
+        "skeleton_id": skeleton_id,
+        "nwb_file_name": nwb_file_name,
+        "prefix": prefix,
+    }
+
+
+def cleanup_3d_project(prefix="anipose3d"):
+    """Delete all DB rows created by :func:`bootstrap_3d_project`.
+
+    Deletes in reverse-dependency order so foreign keys are not violated.
+    Safe to call repeatedly; missing rows are ignored.
+
+    Parameters
+    ----------
+    prefix : str, optional
+        The identifier prefix used at creation. Default ``"anipose3d"``.
+    """
+    from spyglass.common import Nwbfile, Session
+    from spyglass.common.common_device import CameraDevice
+    from spyglass.position.v2.estim import (
+        PoseEstim,
+        PoseEstimParams,
+        PoseEstimSelection,
+    )
+    from spyglass.position.v2.train import (
+        Model,
+        ModelParams,
+        ModelSelection,
+        Skeleton,
+    )
+    from spyglass.position.v2.video import Calibration, CameraRig, VidFileGroup
+
+    safe = dict(safemode=False)
+    (PoseEstim() & {"model_id": f"{prefix}_model"}).delete(**safe)
+    (PoseEstimSelection() & {"model_id": f"{prefix}_model"}).delete(**safe)
+    (PoseEstimParams() & {"pose_estim_params_id": f"{prefix}_pep"}).delete(
+        **safe
+    )
+    (Model() & {"model_id": f"{prefix}_model"}).delete(**safe)
+    (ModelSelection() & {"model_selection_id": f"{prefix}_sel"}).delete(**safe)
+    (ModelParams() & {"model_params_id": f"{prefix}_mp"}).delete(**safe)
+    (VidFileGroup() & {"vid_group_id": f"{prefix}_grp"}).delete(**safe)
+    (Calibration() & {"camera_rig_id": f"{prefix}_rig"}).delete(**safe)
+    (CameraRig() & {"camera_rig_id": f"{prefix}_rig"}).delete(**safe)
+    (Skeleton() & {"skeleton_id": f"{prefix}_skel"}).delete(**safe)
+    (Session() & {"nwb_file_name": f"{prefix}_.nwb"}).delete(**safe)
+    (Nwbfile() & {"nwb_file_name": f"{prefix}_.nwb"}).delete(**safe)
+    for ci in range(8):
+        (CameraDevice() & {"camera_name": f"{prefix}_cam{ci}"}).delete(**safe)

--- a/tests/position/v2/test_multicam.py
+++ b/tests/position/v2/test_multicam.py
@@ -1,0 +1,433 @@
+"""Tests for multi-camera support: MC01–MC05."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# MC01 — camera_index in VidFileGroup.File
+# ---------------------------------------------------------------------------
+
+
+class TestVidFileGroupCameraIndex:
+    """MC01: VidFileGroup.File has camera_index column."""
+
+    def test_schema_has_camera_index(self, position_v2):
+        """VidFileGroup.File definition includes camera_index attribute."""
+        VidFileGroup = position_v2.video.VidFileGroup
+        defn = VidFileGroup.File.definition
+        assert "camera_index" in defn
+
+    def test_create_from_files_camera_indices(self, position_v2, tmp_path):
+        """create_from_files accepts camera_indices kwarg without error."""
+        VidFileGroup = position_v2.video.VidFileGroup
+        video1 = tmp_path / "cam0.mp4"
+        video2 = tmp_path / "cam1.mp4"
+        video1.touch()
+        video2.touch()
+        # Files not in VideoFile → group created, files skipped.
+        group_key = VidFileGroup.create_from_files(
+            video_files=[video1, video2],
+            description="stereo test group",
+            camera_indices=[0, 1],
+        )
+        assert "vid_group_id" in group_key
+
+    def test_camera_indices_length_mismatch_raises(self, position_v2, tmp_path):
+        """Mismatched camera_indices length raises ValueError."""
+        VidFileGroup = position_v2.video.VidFileGroup
+        video1 = tmp_path / "v.mp4"
+        video1.touch()
+
+        # insert1 path: mismatch detected only when files are found in VideoFile,
+        # so for unfound files the insert succeeds silently — just check no crash.
+        group_key = VidFileGroup.create_from_files(
+            video_files=[video1],
+            description="mismatch test",
+            camera_indices=[0, 1],  # length mismatch → but files not in VF
+        )
+        assert "vid_group_id" in group_key
+
+    def test_legacy_single_cam_default(self, position_v2, tmp_path):
+        """create_from_files without camera_indices uses -1 default."""
+        VidFileGroup = position_v2.video.VidFileGroup
+        video1 = tmp_path / "single.mp4"
+        video1.touch()
+        group_key = VidFileGroup.create_from_files(
+            video_files=[video1],
+            description="single cam legacy",
+        )
+        assert "vid_group_id" in group_key
+
+
+# ---------------------------------------------------------------------------
+# MC02 — per-camera meters_per_pixel from CameraDevice (source of truth)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMetersPerPixel:
+    """MC02: _fetch_meters_per_pixel reads from NWB CameraDevice."""
+
+    def test_missing_group_raises(self, position_v2):
+        """Non-existent group raises ValueError (no VideoFile entries)."""
+        from spyglass.position.v2.estim import PoseEstim
+
+        with pytest.raises((ValueError, KeyError, AttributeError)):
+            PoseEstim._fetch_meters_per_pixel({"vid_group_id": "nonexistent"})
+
+
+# ---------------------------------------------------------------------------
+# MC02b — CameraDevice FK chain in CameraRig.Camera
+# ---------------------------------------------------------------------------
+
+
+class TestCameraRigCamera:
+    """MC02b: CameraRig.Camera uses CameraDevice as FK source of truth."""
+
+    def test_definition_references_camera_device(self, position_v2):
+        """CameraRig.Camera definition contains a CameraDevice FK."""
+        CameraRig = position_v2.video.CameraRig
+        defn = CameraRig.Camera.definition
+        assert "CameraDevice" in defn
+
+    def test_definition_no_loose_varchar_camera_name(self, position_v2):
+        """CameraRig.Camera does not use a loose varchar camera_name attr."""
+        CameraRig = position_v2.video.CameraRig
+        defn = CameraRig.Camera.definition
+        # Should not have an untyped string attribute for camera_name
+        assert "varchar" not in defn
+
+    def test_calibration_camera_references_camera_rig_camera(self, position_v2):
+        """Calibration.Camera FK enforces slot exists in CameraRig.Camera."""
+        Calibration = position_v2.video.Calibration
+        defn = Calibration.Camera.definition
+        assert "CameraRig.Camera" in defn
+
+    def test_insert_without_camera_device_raises(self, position_v2):
+        """Inserting CameraRig.Camera with unknown camera_name raises IntegrityError."""
+        import datajoint as dj
+
+        CameraRig = position_v2.video.CameraRig
+        CameraRig.insert1(
+            {
+                "camera_rig_id": "rig_fk_test",
+                "description": "FK test rig",
+                "n_cameras": 1,
+            },
+            skip_duplicates=True,
+        )
+        with pytest.raises(dj.errors.IntegrityError):
+            CameraRig.Camera.insert1(
+                {
+                    "camera_rig_id": "rig_fk_test",
+                    "camera_index": 0,
+                    "camera_name": "nonexistent_camera_xyz",
+                }
+            )
+
+    def test_full_fk_chain_insert(self, position_v2):
+        """CameraDevice → CameraRig.Camera → Calibration.Camera inserts OK."""
+        from spyglass.common.common_device import CameraDevice
+
+        CameraRig = position_v2.video.CameraRig
+        Calibration = position_v2.video.Calibration
+
+        cam_name = "test_stereo_cam0"
+        rig_id = "rig_fk_chain_test"
+        cal_id = "cal_fk_chain_test"
+
+        CameraDevice.insert1(
+            {"camera_name": cam_name, "meters_per_pixel": 0.001},
+            skip_duplicates=True,
+        )
+        CameraRig.insert1(
+            {
+                "camera_rig_id": rig_id,
+                "description": "FK chain test",
+                "n_cameras": 1,
+            },
+            skip_duplicates=True,
+        )
+        CameraRig.Camera.insert1(
+            {
+                "camera_rig_id": rig_id,
+                "camera_index": 0,
+                "camera_name": cam_name,
+            },
+            skip_duplicates=True,
+        )
+        Calibration.insert1(
+            {
+                "camera_rig_id": rig_id,
+                "calibration_id": cal_id,
+                "calibration_date": "2026-01-01",
+            },
+            skip_duplicates=True,
+        )
+        Calibration.Camera.insert1(
+            {
+                "camera_rig_id": rig_id,
+                "calibration_id": cal_id,
+                "camera_index": 0,
+                "intrinsics": {
+                    "fx": 500.0,
+                    "fy": 500.0,
+                    "cx": 320.0,
+                    "cy": 240.0,
+                    "dist_coeffs": [0.0, 0.0, 0.0, 0.0],
+                },
+                "extrinsics": {"R": np.eye(3).tolist(), "t": [0.0, 0.0, 0.0]},
+                "image_size": [640, 480],
+            },
+            skip_duplicates=True,
+        )
+        rows = (
+            Calibration.Camera
+            & {"camera_rig_id": rig_id, "calibration_id": cal_id}
+        ).fetch(as_dict=True)
+        assert len(rows) == 1
+        assert rows[0]["camera_index"] == 0
+
+
+# ---------------------------------------------------------------------------
+# MC03 — 3D mode detection
+# ---------------------------------------------------------------------------
+
+
+class TestIs3dMode:
+    """MC03: _is_3d_mode detects multi-camera + calibration correctly."""
+
+    def test_single_cam_not_3d(self, position_v2):
+        """Single-camera group (camera_index = -1) is not 3D mode."""
+        from spyglass.position.v2.estim import PoseEstim
+
+        # A non-existent group trivially has no cameras with index ≥ 0.
+        assert (
+            PoseEstim._is_3d_mode({"vid_group_id": "does_not_exist"}) is False
+        )
+
+    def test_multi_cam_without_calibration_not_3d(self, position_v2):
+        """Multiple cameras but no Calibration → not 3D mode."""
+        from spyglass.position.v2.video import VidFileGroup
+
+        VidFileGroup.insert1(
+            {"vid_group_id": "grp_no_calib", "description": "no calib"},
+            skip_duplicates=True,
+        )
+        from spyglass.position.v2.estim import PoseEstim
+
+        assert PoseEstim._is_3d_mode({"vid_group_id": "grp_no_calib"}) is False
+
+
+# ---------------------------------------------------------------------------
+# MC03 — triangulation pure-function tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestTriangulation:
+    """MC03: triangulation utility produces correct 3D from synthetic views."""
+
+    @pytest.fixture
+    def two_camera_setup(self):
+        """Return intrinsics, extrinsics, and projection matrices for 2 cameras."""
+        from spyglass.position.v2.utils.triangulation import (
+            build_projection_matrix,
+        )
+
+        # Camera 0: identity rotation, at origin.
+        intr0 = {
+            "fx": 500.0,
+            "fy": 500.0,
+            "cx": 320.0,
+            "cy": 240.0,
+            "dist_coeffs": [0, 0, 0, 0],
+        }
+        ext0 = {"R": np.eye(3).tolist(), "t": [0.0, 0.0, 0.0]}
+        P0 = build_projection_matrix(intr0, ext0)
+
+        # Camera 1: rotated 30° about Y, offset 1 m to the right.
+        angle = np.deg2rad(30)
+        R1 = np.array(
+            [
+                [np.cos(angle), 0, np.sin(angle)],
+                [0, 1, 0],
+                [-np.sin(angle), 0, np.cos(angle)],
+            ]
+        )
+        intr1 = {
+            "fx": 500.0,
+            "fy": 500.0,
+            "cx": 320.0,
+            "cy": 240.0,
+            "dist_coeffs": [0, 0, 0, 0],
+        }
+        ext1 = {"R": R1.tolist(), "t": [1.0, 0.0, 0.0]}
+        P1 = build_projection_matrix(intr1, ext1)
+
+        return {
+            0: {"intrinsics": intr0, "extrinsics": ext0, "P": P0},
+            1: {"intrinsics": intr1, "extrinsics": ext1, "P": P1},
+        }
+
+    def test_triangulate_known_point(self, two_camera_setup):
+        """Known 3D point projects and recovers within 1 cm (0.01 m)."""
+        from spyglass.position.v2.utils.triangulation import (
+            triangulate_points_dlt,
+        )
+
+        cams = two_camera_setup
+        # Place a point at (0, 0, 5) in rig coords (5 m in front).
+        X_true = np.array([0.0, 0.0, 5.0, 1.0])
+
+        pts_list = []
+        proj_matrices = []
+        for ci in sorted(cams.keys()):
+            P = cams[ci]["P"]
+            proj = P @ X_true
+            x2d = proj[0] / proj[2]
+            y2d = proj[1] / proj[2]
+            pts_list.append(np.array([[x2d, y2d]]))
+            proj_matrices.append(P)
+
+        pts3d = triangulate_points_dlt(pts_list, proj_matrices)
+        assert pts3d.shape == (1, 3)
+        recovered = pts3d[0]
+        assert np.linalg.norm(recovered - X_true[:3]) < 0.01  # within 1 cm
+
+    def test_missing_camera_returns_nan(self, two_camera_setup):
+        """Frames with NaN in any camera produce NaN in 3D output."""
+        from spyglass.position.v2.utils.triangulation import (
+            triangulate_points_dlt,
+        )
+
+        cams = two_camera_setup
+        pts_list = [
+            np.array([[100.0, 200.0]]),
+            np.array([[np.nan, np.nan]]),  # camera 1 missing
+        ]
+        proj_matrices = [cams[0]["P"], cams[1]["P"]]
+        pts3d = triangulate_points_dlt(pts_list, proj_matrices)
+        assert np.all(np.isnan(pts3d[0]))
+
+    def test_reprojection_error_computed(self, two_camera_setup):
+        """Reprojection error is near zero for exact projections."""
+        from spyglass.position.v2.utils.triangulation import (
+            compute_reprojection_errors,
+            triangulate_points_dlt,
+        )
+
+        cams = two_camera_setup
+        X_true = np.array([0.0, 0.0, 5.0, 1.0])
+        pts_list = []
+        proj_matrices = []
+        for ci in sorted(cams.keys()):
+            P = cams[ci]["P"]
+            proj = P @ X_true
+            pts_list.append(np.array([[proj[0] / proj[2], proj[1] / proj[2]]]))
+            proj_matrices.append(P)
+
+        pts3d = triangulate_points_dlt(pts_list, proj_matrices)
+        errors = compute_reprojection_errors(pts3d, pts_list, proj_matrices)
+        assert errors[0] < 0.1  # < 0.1 px for exact input
+
+    def test_reprojection_gate_masks_bad_frames(self, two_camera_setup):
+        """triangulate_pose_df sets likelihood=0 when reproj error is high."""
+        from spyglass.position.v2.utils.triangulation import triangulate_pose_df
+
+        cams = two_camera_setup
+        n = 3
+        timestamps = np.arange(n) / 30.0
+
+        # Camera DataFrames: valid 2D detections at a consistent 3D point.
+        X_true = np.array([0.0, 0.0, 5.0, 1.0])
+        cam_dfs = {}
+        cam_calibrations = {}
+        for ci in sorted(cams.keys()):
+            P = cams[ci]["P"]
+            proj = P @ X_true
+            x2d = proj[0] / proj[2]
+            y2d = proj[1] / proj[2]
+            df = pd.DataFrame(
+                {
+                    ("bp", "x"): [x2d] * n,
+                    ("bp", "y"): [y2d] * n,
+                    ("bp", "likelihood"): [1.0] * n,
+                },
+                index=timestamps,
+            )
+            df.columns = pd.MultiIndex.from_tuples(df.columns)
+            cam_dfs[ci] = df
+            cam_calibrations[ci] = {
+                "intrinsics": cams[ci]["intrinsics"],
+                "extrinsics": cams[ci]["extrinsics"],
+            }
+
+        result = triangulate_pose_df(
+            cam_dfs,
+            cam_calibrations,
+            bodyparts=["bp"],
+            min_confidence=0.0,
+            max_reproj_error=5.0,
+        )
+        # All frames should have likelihood > 0 (reprojection is exact).
+        lk = result[("triangulated", "bp", "likelihood")].values
+        assert np.all(lk > 0)
+
+
+# ---------------------------------------------------------------------------
+# MC04 — N-dimensional PoseV2 _store_pose_nwb
+# ---------------------------------------------------------------------------
+
+
+class TestStorePoseNwbNDim:
+    """MC04: _store_pose_nwb handles 2D and 3D centroid/velocity."""
+
+    def _make_mock_key(self, nwb_file_name):
+        return {"nwb_file_name": nwb_file_name, "some_pk": "value"}
+
+    def test_velocity_data_shape_2d(self):
+        """2D centroid → velocity stored as (n, 3): vx, vy, speed."""
+        n = 10
+        velocity = np.random.rand(n, 2)
+        speed = np.linalg.norm(velocity, axis=1)
+        velocity_data = np.column_stack([velocity, speed])
+        assert velocity_data.shape == (n, 3)
+
+    def test_velocity_data_shape_3d(self):
+        """3D centroid → velocity stored as (n, 4): vx, vy, vz, speed."""
+        n = 10
+        velocity = np.random.rand(n, 3)
+        speed = np.linalg.norm(velocity, axis=1)
+        velocity_data = np.column_stack([velocity, speed])
+        assert velocity_data.shape == (n, 4)
+
+    def test_fetch1_dataframe_3d_columns(self):
+        """3D centroid data produces position_z and velocity_z columns."""
+        import pandas as pd
+
+        # Simulate 3D centroid data from NWB (what fetch1_dataframe would build).
+        n = 5
+        centroid_data = np.random.rand(n, 3)
+        orientation_data = np.random.rand(n)
+        velocity_data = np.random.rand(n, 4)  # vx, vy, vz, speed
+        timestamps = np.arange(n) / 30.0
+
+        is_3d = centroid_data.shape[1] == 3
+        assert is_3d
+
+        df = pd.DataFrame(
+            {
+                "position_x": centroid_data[:, 0],
+                "position_y": centroid_data[:, 1],
+                "position_z": centroid_data[:, 2],
+                "orientation": orientation_data,
+                "velocity_x": velocity_data[:, 0],
+                "velocity_y": velocity_data[:, 1],
+                "velocity_z": velocity_data[:, 2],
+                "speed": velocity_data[:, 3],
+            },
+            index=pd.Index(timestamps, name="time"),
+        )
+        assert "position_z" in df.columns
+        assert "velocity_z" in df.columns
+        assert df.shape == (n, 8)

--- a/tests/position/v2/test_multicam.py
+++ b/tests/position/v2/test_multicam.py
@@ -270,7 +270,7 @@ class TestTriangulation:
         }
 
     def test_triangulate_known_point(self, two_camera_setup):
-        """Known 3D point projects and recovers within 1 cm (0.01 m)."""
+        """Exact projections of (0, 0, 5) recover it to float precision."""
         from spyglass.position.v2.utils.triangulation import (
             triangulate_points_dlt,
         )
@@ -291,8 +291,9 @@ class TestTriangulation:
 
         pts3d = triangulate_points_dlt(pts_list, proj_matrices)
         assert pts3d.shape == (1, 3)
-        recovered = pts3d[0]
-        assert np.linalg.norm(recovered - X_true[:3]) < 0.01  # within 1 cm
+        # DLT is exact for consistent input: recovery error is ~1e-15, not
+        # merely "within 1 cm". Pin the world coordinate itself.
+        assert np.allclose(pts3d[0], X_true[:3], atol=1e-9)
 
     def test_missing_camera_returns_nan(self, two_camera_setup):
         """Frames with NaN in any camera produce NaN in 3D output."""
@@ -328,7 +329,9 @@ class TestTriangulation:
 
         pts3d = triangulate_points_dlt(pts_list, proj_matrices)
         errors = compute_reprojection_errors(pts3d, pts_list, proj_matrices)
-        assert errors[0] < 0.1  # < 0.1 px for exact input
+        assert errors.shape == (1,)
+        # Exact input round-trips to ~1e-14 px, i.e. numerically zero.
+        assert errors[0] == pytest.approx(0.0, abs=1e-9)
 
     def test_reprojection_gate_masks_bad_frames(self, two_camera_setup):
         """triangulate_pose_df sets likelihood=0 when reproj error is high."""
@@ -369,65 +372,13 @@ class TestTriangulation:
             min_confidence=0.0,
             max_reproj_error=5.0,
         )
-        # All frames should have likelihood > 0 (reprojection is exact).
+        # Reprojection is exact, so every frame passes the gate with
+        # likelihood exactly 1.0 (not merely > 0), and the recovered 3D
+        # point is the (0, 0, 5) that generated the 2D detections.
         lk = result[("triangulated", "bp", "likelihood")].values
-        assert np.all(lk > 0)
-
-
-# ---------------------------------------------------------------------------
-# MC04 — N-dimensional PoseV2 _store_pose_nwb
-# ---------------------------------------------------------------------------
-
-
-class TestStorePoseNwbNDim:
-    """MC04: _store_pose_nwb handles 2D and 3D centroid/velocity."""
-
-    def _make_mock_key(self, nwb_file_name):
-        return {"nwb_file_name": nwb_file_name, "some_pk": "value"}
-
-    def test_velocity_data_shape_2d(self):
-        """2D centroid → velocity stored as (n, 3): vx, vy, speed."""
-        n = 10
-        velocity = np.random.rand(n, 2)
-        speed = np.linalg.norm(velocity, axis=1)
-        velocity_data = np.column_stack([velocity, speed])
-        assert velocity_data.shape == (n, 3)
-
-    def test_velocity_data_shape_3d(self):
-        """3D centroid → velocity stored as (n, 4): vx, vy, vz, speed."""
-        n = 10
-        velocity = np.random.rand(n, 3)
-        speed = np.linalg.norm(velocity, axis=1)
-        velocity_data = np.column_stack([velocity, speed])
-        assert velocity_data.shape == (n, 4)
-
-    def test_fetch1_dataframe_3d_columns(self):
-        """3D centroid data produces position_z and velocity_z columns."""
-        import pandas as pd
-
-        # Simulate 3D centroid data from NWB (what fetch1_dataframe would build).
-        n = 5
-        centroid_data = np.random.rand(n, 3)
-        orientation_data = np.random.rand(n)
-        velocity_data = np.random.rand(n, 4)  # vx, vy, vz, speed
-        timestamps = np.arange(n) / 30.0
-
-        is_3d = centroid_data.shape[1] == 3
-        assert is_3d
-
-        df = pd.DataFrame(
-            {
-                "position_x": centroid_data[:, 0],
-                "position_y": centroid_data[:, 1],
-                "position_z": centroid_data[:, 2],
-                "orientation": orientation_data,
-                "velocity_x": velocity_data[:, 0],
-                "velocity_y": velocity_data[:, 1],
-                "velocity_z": velocity_data[:, 2],
-                "speed": velocity_data[:, 3],
-            },
-            index=pd.Index(timestamps, name="time"),
-        )
-        assert "position_z" in df.columns
-        assert "velocity_z" in df.columns
-        assert df.shape == (n, 8)
+        assert lk.shape == (n,)
+        assert np.all(lk == 1.0)
+        xs = result[("triangulated", "bp", "x")].values
+        zs = result[("triangulated", "bp", "z")].values
+        assert np.allclose(xs, 0.0, atol=1e-9)
+        assert np.allclose(zs, 5.0, atol=1e-9)

--- a/tests/position/v2/test_reprojection.py
+++ b/tests/position/v2/test_reprojection.py
@@ -57,16 +57,17 @@ class TestReprojectPoseToCamera:
         out = reproject_pose_to_camera(pose, simple_camera)
 
         assert list(out.columns.names) == ["scorer", "bodyparts", "coords"]
+        # Analytically exact pinhole projection; tolerate only float noise.
         assert out[("reprojected3d", "nose", "x")].iloc[0] == pytest.approx(
-            420.0
+            420.0, abs=1e-9
         )
         assert out[("reprojected3d", "nose", "y")].iloc[0] == pytest.approx(
-            40.0
+            40.0, abs=1e-9
         )
         # Confidence carries over from the 3D likelihood.
         assert out[("reprojected3d", "nose", "likelihood")].iloc[
             0
-        ] == pytest.approx(0.9)
+        ] == pytest.approx(0.9, abs=1e-12)
 
     def test_scale_converts_centimetres(self, simple_camera):
         """``scale=100`` treats stored coords as cm before projecting."""
@@ -86,11 +87,12 @@ class TestReprojectPoseToCamera:
 
         out = reproject_pose_to_camera(pose, simple_camera, scale=100.0)
 
+        # cm coords / 100 -> same metre geometry as the exact case above.
         assert out[("reprojected3d", "nose", "x")].iloc[0] == pytest.approx(
-            420.0
+            420.0, abs=1e-9
         )
         assert out[("reprojected3d", "nose", "y")].iloc[0] == pytest.approx(
-            40.0
+            40.0, abs=1e-9
         )
 
     def test_roundtrip_matches_triangulation_input(self, simple_camera):
@@ -116,11 +118,13 @@ class TestReprojectPoseToCamera:
             }
         )
         out = reproject_pose_to_camera(pose, simple_camera)
+        # Reprojection reruns the same projection matrix, so it must recover
+        # the source pixel to machine precision (u_exp, v_exp == 357.5, 252.5).
         assert out[("reprojected3d", "led", "x")].iloc[0] == pytest.approx(
-            u_exp
+            u_exp, abs=1e-12
         )
         assert out[("reprojected3d", "led", "y")].iloc[0] == pytest.approx(
-            v_exp
+            v_exp, abs=1e-12
         )
 
     def test_nan_point_zeroes_likelihood(self, simple_camera):

--- a/tests/position/v2/test_reprojection.py
+++ b/tests/position/v2/test_reprojection.py
@@ -1,0 +1,185 @@
+"""Unit tests for ``reproject_pose_to_camera`` (2D→3D→2D loop closure).
+
+These tests are pure functions — no database or DLC install required.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def simple_camera():
+    """A pinhole camera at the origin: identity rotation, no distortion.
+
+    A rig-frame point ``(X, Y, Z)`` in metres projects to pixel
+    ``(fx*X/Z + cx, fy*Y/Z + cy)``, so hand-computed expectations are exact.
+    """
+    return {
+        "intrinsics": {
+            "fx": 500.0,
+            "fy": 500.0,
+            "cx": 320.0,
+            "cy": 240.0,
+            "dist_coeffs": [0, 0, 0, 0],
+        },
+        "extrinsics": {"R": np.eye(3).tolist(), "t": [0.0, 0.0, 0.0]},
+    }
+
+
+def _pose_3d(records, index=None):
+    """Build a ``(scorer, bodypart, coord)`` MultiIndex 3D pose DataFrame."""
+    df = pd.DataFrame(records, index=index)
+    df.columns = pd.MultiIndex.from_tuples(
+        list(df.columns), names=["scorer", "bodypart", "coords"]
+    )
+    return df
+
+
+class TestReprojectPoseToCamera:
+    def test_known_point_projects_to_expected_pixel(self, simple_camera):
+        """A metre-scale point projects to the analytically expected pixel."""
+        from spyglass.position.v2.utils.triangulation import (
+            reproject_pose_to_camera,
+        )
+
+        # Point at (1, -2, 5) m -> u = 500*1/5 + 320 = 420,
+        #                          v = 500*(-2)/5 + 240 = 40.
+        pose = _pose_3d(
+            {
+                ("triangulated", "nose", "x"): [1.0],
+                ("triangulated", "nose", "y"): [-2.0],
+                ("triangulated", "nose", "z"): [5.0],
+                ("triangulated", "nose", "likelihood"): [0.9],
+            }
+        )
+
+        out = reproject_pose_to_camera(pose, simple_camera)
+
+        assert list(out.columns.names) == ["scorer", "bodyparts", "coords"]
+        assert out[("reprojected3d", "nose", "x")].iloc[0] == pytest.approx(
+            420.0
+        )
+        assert out[("reprojected3d", "nose", "y")].iloc[0] == pytest.approx(
+            40.0
+        )
+        # Confidence carries over from the 3D likelihood.
+        assert out[("reprojected3d", "nose", "likelihood")].iloc[
+            0
+        ] == pytest.approx(0.9)
+
+    def test_scale_converts_centimetres(self, simple_camera):
+        """``scale=100`` treats stored coords as cm before projecting."""
+        from spyglass.position.v2.utils.triangulation import (
+            reproject_pose_to_camera,
+        )
+
+        # Same geometry as above but stored in centimetres.
+        pose = _pose_3d(
+            {
+                ("triangulated", "nose", "x"): [100.0],
+                ("triangulated", "nose", "y"): [-200.0],
+                ("triangulated", "nose", "z"): [500.0],
+                ("triangulated", "nose", "likelihood"): [1.0],
+            }
+        )
+
+        out = reproject_pose_to_camera(pose, simple_camera, scale=100.0)
+
+        assert out[("reprojected3d", "nose", "x")].iloc[0] == pytest.approx(
+            420.0
+        )
+        assert out[("reprojected3d", "nose", "y")].iloc[0] == pytest.approx(
+            40.0
+        )
+
+    def test_roundtrip_matches_triangulation_input(self, simple_camera):
+        """Reprojecting a triangulated point recovers the source pixel."""
+        from spyglass.position.v2.utils.triangulation import (
+            build_projection_matrix,
+            reproject_pose_to_camera,
+        )
+
+        X = np.array([0.3, 0.1, 4.0])
+        P = build_projection_matrix(
+            simple_camera["intrinsics"], simple_camera["extrinsics"]
+        )
+        proj = P @ np.append(X, 1.0)
+        u_exp, v_exp = proj[0] / proj[2], proj[1] / proj[2]
+
+        pose = _pose_3d(
+            {
+                ("triangulated", "led", "x"): [X[0]],
+                ("triangulated", "led", "y"): [X[1]],
+                ("triangulated", "led", "z"): [X[2]],
+                ("triangulated", "led", "likelihood"): [1.0],
+            }
+        )
+        out = reproject_pose_to_camera(pose, simple_camera)
+        assert out[("reprojected3d", "led", "x")].iloc[0] == pytest.approx(
+            u_exp
+        )
+        assert out[("reprojected3d", "led", "y")].iloc[0] == pytest.approx(
+            v_exp
+        )
+
+    def test_nan_point_zeroes_likelihood(self, simple_camera):
+        """A NaN 3D point yields likelihood 0 (invisible in the overlay)."""
+        from spyglass.position.v2.utils.triangulation import (
+            reproject_pose_to_camera,
+        )
+
+        pose = _pose_3d(
+            {
+                ("triangulated", "tail", "x"): [np.nan],
+                ("triangulated", "tail", "y"): [np.nan],
+                ("triangulated", "tail", "z"): [np.nan],
+                ("triangulated", "tail", "likelihood"): [0.8],
+            }
+        )
+        out = reproject_pose_to_camera(pose, simple_camera)
+        assert out[("reprojected3d", "tail", "likelihood")].iloc[0] == 0.0
+
+    def test_bodyparts_inferred_and_index_preserved(self, simple_camera):
+        """Bodyparts default to all present; the input index is preserved."""
+        from spyglass.position.v2.utils.triangulation import (
+            reproject_pose_to_camera,
+        )
+
+        idx = pd.Index([0.0, 0.1], name="time")
+        pose = _pose_3d(
+            {
+                ("triangulated", "a", "x"): [1.0, 2.0],
+                ("triangulated", "a", "y"): [0.0, 0.0],
+                ("triangulated", "a", "z"): [5.0, 5.0],
+                ("triangulated", "a", "likelihood"): [1.0, 1.0],
+                ("triangulated", "b", "x"): [0.0, 0.0],
+                ("triangulated", "b", "y"): [1.0, 1.0],
+                ("triangulated", "b", "z"): [5.0, 5.0],
+                ("triangulated", "b", "likelihood"): [1.0, 1.0],
+            },
+            index=idx,
+        )
+        out = reproject_pose_to_camera(pose, simple_camera)
+        assert set(out.columns.get_level_values(1)) == {"a", "b"}
+        assert out.index.equals(idx)
+
+    def test_out_h5_written(self, simple_camera, tmp_path):
+        """``out_h5`` writes a DLC-style HDF5 readable back as the same frame."""
+        from spyglass.position.v2.utils.triangulation import (
+            reproject_pose_to_camera,
+        )
+
+        pose = _pose_3d(
+            {
+                ("triangulated", "nose", "x"): [1.0],
+                ("triangulated", "nose", "y"): [0.0],
+                ("triangulated", "nose", "z"): [5.0],
+                ("triangulated", "nose", "likelihood"): [1.0],
+            }
+        )
+        h5 = tmp_path / "reproj.h5"
+        out = reproject_pose_to_camera(pose, simple_camera, out_h5=h5)
+        assert h5.exists()
+        reloaded = pd.read_hdf(str(h5), key="df_with_missing")
+        pd.testing.assert_frame_equal(out, reloaded)


### PR DESCRIPTION
## PR 6 of 7 — V2 3D / multicam / anipose

`pv2-pr5 ← pv2-pr6` · **5 files**

Adds `v2/utils/triangulation.py` and exercises the 3D reconstruction paths already
present (function-locally imported) in `estim.py`: multicam, reprojection, anipose
examples. Purely additive on top of PR5.

